### PR TITLE
Exit loop waiting for connection on node removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>mesos</artifactId>
-  <version>0.16.100</version>
+  <version>0.16.101-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Mesos+Plugin</url>
   <description>Allows the dynamic launch Jenkins agent on a Mesos cluster, depending on workload</description>

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -129,7 +129,7 @@ public class MesosComputerLauncher extends JNLPLauncher {
   }
 
   private void waitForSlaveConnection(MesosComputer computer, PrintStream logger) {
-    while (computer.isOffline() && computer.isConnecting()) {
+    while (computer.isOffline() && computer.isConnecting() && computer.getOfflineCause() == null) {
       try {
         logger.println("Waiting for slave computer connection " + name);
         Thread.sleep(5000);


### PR DESCRIPTION
The loop that waits for an agent on mesos to connect assumes the
Computer is always valid. It is possible that a clean-up process
marked the Computer for removal and will loop forever (the agent
will never connect).

This change looks to see if the OfflineClause was set and if so,
no longer waits for a connection.