### PR TITLE
Add Single Use property to MesosSlave

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -73,17 +73,17 @@ public class MesosRetentionStrategy extends RetentionStrategy<MesosComputer> {
       return 1;
     }
 
-    // If we just launched this computer, check back after 1 min.
-    // NOTE: 'c.getConnectTime()' refers to when the Jenkins slave was launched.
-    if ((DateTimeUtils.currentTimeMillis() - c.getConnectTime()) <
-        MINUTES.toMillis(idleTerminationMinutes < 1 ? 1 : idleTerminationMinutes)) {
-      return 1;
-    }
-
     // Terminate if the computer is idle and a single-use agent.
     if (c.isIdle() && c.isOffline() && node.isSingleUse()) {
       LOGGER.info("Disconnecting single-use computer " + c.getName());
       node.setPendingDelete(true);
+      return 1;
+    }
+
+    // If we just launched this computer, check back after 1 min.
+    // NOTE: 'c.getConnectTime()' refers to when the Jenkins slave was launched.
+    if ((DateTimeUtils.currentTimeMillis() - c.getConnectTime()) <
+        MINUTES.toMillis(idleTerminationMinutes < 1 ? 1 : idleTerminationMinutes)) {
       return 1;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -80,6 +80,13 @@ public class MesosRetentionStrategy extends RetentionStrategy<MesosComputer> {
       return 1;
     }
 
+    // Terminate if the computer is idle and a single-use agent.
+    if (c.isIdle() && c.isOffline() && node.isSingleUse()) {
+      LOGGER.info("Disconnecting single-use computer " + c.getName());
+      node.setPendingDelete(true);
+      return 1;
+    }
+
     // Terminate the computer if it is idle for longer than
     // 'idleTerminationMinutes'.
     if (isTerminable() && c.isIdle()) {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
@@ -57,6 +57,22 @@ public class MesosSingleUseSlave extends SimpleBuildWrapper {
     @Override
     public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
         context.setDisposer(new MesosSingleUseSlaveDisposer());
+
+        Computer computer = workspace.toComputer();
+        if (computer != null) {
+            if (MesosComputer.class.isInstance(computer)) {
+                String msg = "Marking " + computer.getName() + " as single-use.";
+                LOGGER.warning(msg);
+                listener.getLogger().println(msg);
+
+                MesosSlave mesosSlave = (MesosSlave) computer.getNode();
+                if (mesosSlave != null) {
+                    mesosSlave.setSingleUse(true);
+                }
+            } else {
+                listener.getLogger().println("Not able to set single-use slave, this is a " + computer.getClass());
+            }
+        }
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -37,6 +37,8 @@ public class MesosSlave extends Slave {
 
   private static final long serialVersionUID = 1L;
 
+  private final Object lock = new Object();
+
   private final String cloudName;
   private transient MesosCloud cloud;
   private final MesosSlaveInfo slaveInfo;
@@ -186,11 +188,15 @@ public class MesosSlave extends Slave {
   }
 
   public boolean isSingleUse() {
-    return singleUse;
+    synchronized (lock) {
+      return singleUse;
+    }
   }
 
   public void setSingleUse(boolean singleUse) {
-    this.singleUse = singleUse;
+    synchronized (lock) {
+      this.singleUse = singleUse;
+    }
   }
 
   public void idleTimeout() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -180,11 +180,15 @@ public class MesosSlave extends Slave {
   }
 
   public boolean isPendingDelete() {
+    synchronized (lock) {
       return pendingDelete;
+    }
   }
 
   public void setPendingDelete(boolean pendingDelete) {
+    synchronized (lock) {
       this.pendingDelete = pendingDelete;
+    }
   }
 
   public boolean isSingleUse() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -49,6 +49,7 @@ public class MesosSlave extends Slave {
   private transient final Timer.Context provisionToMesos;
   private transient final Timer mesosToReady;
   private transient long mesosHandoffTime;
+  private boolean singleUse;
 
 
   private boolean pendingDelete;
@@ -82,6 +83,7 @@ public class MesosSlave extends Slave {
     this.provisionToReady = provisionToReadyContext;
     this.provisionToMesos = provisionToMesosContext;
     this.mesosToReady = mesosToReady;
+    this.singleUse = false;
     LOGGER.fine("Constructing Mesos slave " + name + " from cloud " + cloud.getDescription());
   }
 
@@ -181,6 +183,14 @@ public class MesosSlave extends Slave {
 
   public void setPendingDelete(boolean pendingDelete) {
       this.pendingDelete = pendingDelete;
+  }
+
+  public boolean isSingleUse() {
+    return singleUse;
+  }
+
+  public void setSingleUse(boolean singleUse) {
+    this.singleUse = singleUse;
   }
 
   public void idleTimeout() {


### PR DESCRIPTION
Single-use agents are marked offline and then still wait for idle timeout before being deleted/removed. This commit adds a new property to MesosSlave to mark nodes as single-use agents. This is read during the retention check and used to mark a cluster for deletion.

This change still takes a retention cycle (up to 1 minute) and cleanup thread cycle (up to 1 minute) after the workload has completed before the agent is removed.