### PR TITLE
Start sleeping task with USI.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 ext {
-    usiBranch = 'master'
+    usiBranch = 'karsten/simple-flow'
 }
 
 dependencies {
@@ -23,7 +23,7 @@ dependencies {
     implementation('com.mesosphere.usi:core-models') { version { branch = usiBranch } }
     implementation('com.mesosphere.usi:mesos-client') { version { branch = usiBranch } }
 
-    // Test dependencie
+    // Test dependencies
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     testImplementation('com.mesosphere.usi:test-utils') { version { branch = usiBranch } }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 ext {
-    usiBranch = 'karsten/simple-flow'
+    usiBranch = 'karsten/java-api'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation('com.mesosphere.usi:core') { version { branch = usiBranch } }
     implementation('com.mesosphere.usi:core-models') { version { branch = usiBranch } }
     implementation('com.mesosphere.usi:mesos-client') { version { branch = usiBranch } }
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
 
     // Test dependencies
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 ext {
-    usiBranch = 'karsten/java-api'
+    usiBranch = 'master'
 }
 
 dependencies {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -81,6 +81,15 @@ public class MesosApi {
     updates = runUsi(SpecsSnapshot.empty(), client, materializer);
   }
 
+  /**
+   * Constructs a queue of {@link SpecUpdated} and passes the specs snapshot as the first item. All
+   * updates are processed by {@link MesosApi#updateState(StateEvent)}.
+   *
+   * @param specsSnapshot The initial set of pod specs.
+   * @param client The Mesos client that is used.
+   * @param materializer The {@link ActorMaterializer} used for the source queue.
+   * @return A running source queue.
+   */
   private SourceQueueWithComplete<SpecEvent> runUsi(
       SpecsSnapshot specsSnapshot, MesosClient client, ActorMaterializer materializer) {
     var schedulerFlow = Scheduler.fromClient(client);
@@ -90,7 +99,7 @@ public class MesosApi {
             .prefixAndTail(1)
             .map(
                 pair -> {
-                  var snapshot = (SpecsSnapshot) pair.first();
+                  var snapshot = (SpecsSnapshot) pair.first().get(0);
                   Source<SpecUpdated, Object> updates =
                       pair.second()
                           .map(event -> (SpecUpdated) event)

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -86,6 +86,7 @@ public class MesosApi {
   /**
    * Helper method that terminates the completes scheduler flow if on internal source or flow stops.
    * See {@link MesosApi#runUsi(SpecsSnapshot, MesosClient, ActorMaterializer)}.
+   *
    * @param input Source of state events.
    * @param killSwitch The kill switch that should be triggered.
    * @return A new source with state events and a kill switch in place.
@@ -128,8 +129,7 @@ public class MesosApi {
             .via(killSwitch.flow())
             .via(schedulerFlow)
             .flatMapConcat( // Ignore state snapshot for now.
-                pair ->
-                    triggerKillSwitch(pair.second(), killSwitch))
+                pair -> triggerKillSwitch(pair.second(), killSwitch))
             .via(killSwitch.flow())
             .toMat(Sink.foreach(this::updateState), Keep.left())
             .run(materializer);
@@ -183,8 +183,7 @@ public class MesosApi {
                 Arrays.asList(ScalarRequirement.cpus(cpu), ScalarRequirement.memory(mem))),
             "echo Hello! && sleep 1000000",
             role,
-            convertListToSeq(Collections.emptyList()))
-        ;
+            convertListToSeq(Collections.emptyList()));
     String id = UUID.randomUUID().toString();
     PodSpec podSpec =
         new PodSpec(new PodId(String.format("jenkins-test-%s", id)), Running$.MODULE$, spec);

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -94,6 +94,7 @@ public class MesosApi {
       SpecsSnapshot specsSnapshot, MesosClient client, ActorMaterializer materializer) {
     var schedulerFlow = Scheduler.fromClient(client);
 
+    // We create a SourceQueue and assume that the very first item is a spec snapshot.
     var queue =
         Source.<SpecEvent>queue(256, OverflowStrategy.fail())
             .prefixAndTail(1)
@@ -107,7 +108,7 @@ public class MesosApi {
                   return new Pair<SpecsSnapshot, Source<SpecUpdated, Object>>(snapshot, updates);
                 })
             .via(schedulerFlow)
-            .flatMapConcat(pair -> pair.second())
+            .flatMapConcat(pair -> pair.second()) // Ignore state snapshot for now.
             .toMat(Sink.foreach(this::updateState), Keep.left())
             .run(materializer);
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -2,18 +2,31 @@ package org.jenkinsci.plugins.mesos;
 
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
+import akka.stream.OverflowStrategy;
 import akka.stream.javadsl.Sink;
 import com.mesosphere.mesos.client.MesosClient;
 import com.mesosphere.mesos.client.MesosClient$;
 import com.mesosphere.mesos.conf.MesosClientSettings;
+import com.mesosphere.usi.core.models.*;
+import com.mesosphere.usi.core.models.resources.ResourceRequirement;
+import com.mesosphere.usi.core.models.resources.ScalarRequirement;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
+import com.mesosphere.usi.core.javaapi.SchedulerAdapter;
+import com.mesosphere.usi.core.Scheduler;
+import scala.collection.JavaConverters;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.mesos.v1.Protos;
+import scala.collection.Seq;
+import scala.concurrent.ExecutionContext;
 
 public class MesosApi {
 
@@ -22,9 +35,11 @@ public class MesosApi {
   private final Protos.FrameworkID frameworkId;
   private final MesosClientSettings clientSettings;
   private final MesosClient client;
+  private final SchedulerAdapter adapter;
 
   private final ActorSystem system;
   private final ActorMaterializer materializer;
+  private final ExecutionContext context;
 
   /**
    * Establishes a connection to Mesos and provides a simple interface to start and stop {@link
@@ -49,9 +64,11 @@ public class MesosApi {
             .withValue("master-url", ConfigValueFactory.fromAnyRef(masterUrl));
     this.clientSettings = MesosClientSettings.fromConfig(conf);
     system = ActorSystem.create("mesos-scheduler");
+    context = system.dispatcher();
     materializer = ActorMaterializer.create(system);
-
     client = connectClient().get();
+
+    adapter = new SchedulerAdapter(Scheduler.fromClient(client), materializer, context);
   }
 
   /**
@@ -60,6 +77,10 @@ public class MesosApi {
    * @return A future reference to the {@link MesosSlave}.
    */
   public CompletableFuture<MesosSlave> startAgent() {
+    PodSpec spec = buildMesosAgentTask(0.1, 32);
+    SpecsSnapshot snapshot = new SpecsSnapshot(convertListToSeq(Arrays.asList(spec)), null);
+    adapter.asAkkaQueues(snapshot, OverflowStrategy.backpressure()).t1();
+
     throw new NotImplementedException();
   }
 
@@ -81,5 +102,23 @@ public class MesosApi {
         .apply(clientSettings, frameworkInfo, system, materializer)
         .runWith(Sink.head(), materializer)
         .toCompletableFuture();
+  }
+
+  private PodSpec buildMesosAgentTask(double cpu, double mem) {
+    RunSpec spec = new RunSpec(
+        convertListToSeq(Arrays.asList(ScalarRequirement.cpus(cpu), ScalarRequirement.memory(mem))),
+        "echo Hello!",
+        convertListToSeq(Collections.emptyList())
+    );
+    PodSpec podSpec = new PodSpec(
+        new PodId("jenkins-test"),
+        new Goal.Running$(),
+        spec
+    );
+    return podSpec;
+  }
+
+  private <T> Seq<T> convertListToSeq(List<T> inputList) {
+    return JavaConverters.asScalaIteratorConverter(inputList.iterator()).asScala().toSeq();
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -66,7 +66,8 @@ class MesosCloud extends AbstractCloudImpl {
    * @return A future reference to the launched node.
    */
   private CompletableFuture<Node> startAgent() {
-    mesos.startAgent().thenCompose(mesosSlave -> mesosSlave.waitUntilOnlineAsync());
+    //mesos.startAgent().thenCompose(mesosSlave -> mesosSlave.waitUntilOnlineAsync());
+    mesos.enqueueAgent();
     throw new NotImplementedException();
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -66,7 +66,7 @@ class MesosCloud extends AbstractCloudImpl {
    * @return A future reference to the launched node.
    */
   private CompletableFuture<Node> startAgent() {
-    //mesos.startAgent().thenCompose(mesosSlave -> mesosSlave.waitUntilOnlineAsync());
+    // mesos.startAgent().thenCompose(mesosSlave -> mesosSlave.waitUntilOnlineAsync());
     mesos.enqueueAgent();
     throw new NotImplementedException();
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -67,7 +67,7 @@ class MesosCloud extends AbstractCloudImpl {
    */
   private CompletableFuture<Node> startAgent() {
     // mesos.startAgent().thenCompose(mesosSlave -> mesosSlave.waitUntilOnlineAsync());
-    mesos.enqueueAgent();
+    // mesos.enqueueAgent();
     throw new NotImplementedException();
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -66,8 +66,7 @@ class MesosCloud extends AbstractCloudImpl {
    * @return A future reference to the launched node.
    */
   private CompletableFuture<Node> startAgent() {
-    // mesos.startAgent().thenCompose(mesosSlave -> mesosSlave.waitUntilOnlineAsync());
-    // mesos.enqueueAgent();
+    // mesos.enqueueAgent().thenCompose(mesosSlave -> mesosSlave.waitUntilOnlineAsync());
     throw new NotImplementedException();
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -56,7 +56,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
   }
 
   /** @return whether the agent is running or not. */
-  public boolean isRunning() {
+  public synchronized boolean isRunning() {
     if (currentStatus.isPresent()) {
       return currentStatus
           .get()
@@ -73,7 +73,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
    *
    * @param event The state event from USI which informs about the task status.
    */
-  public void update(PodStatusUpdated event) {
+  public synchronized void update(PodStatusUpdated event) {
     if (event.newStatus().isDefined()) {
       logger.info("Received new status for {}", event.id().value());
       this.currentStatus = Optional.of(event.newStatus().get());

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.mesos;
 
+import com.mesosphere.usi.core.models.PodStateEvent;
 import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.model.TaskListener;
@@ -27,6 +28,13 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
   public CompletableFuture<MesosSlave> waitUntilOnlineAsync() {
     throw new NotImplementedException();
   }
+
+  /**
+   * Updates the state of the slave.
+   *
+   * @param event The state event from USI which informs about the task status.
+   */
+  public void update(PodStateEvent event) {}
 
   @Override
   public Node asNode() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -24,6 +24,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
 
   private static final Logger logger = LoggerFactory.getLogger(MesosSlave.class);
 
+  // Holds the current USI status for this agent.
   Optional<PodStatus> currentStatus = Optional.empty();
 
   public MesosSlave(
@@ -54,6 +55,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
     throw new NotImplementedException();
   }
 
+  /** @return whether the agent is running or not. */
   public boolean isRunning() {
     if (currentStatus.isPresent()) {
       return currentStatus
@@ -72,7 +74,6 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
    * @param event The state event from USI which informs about the task status.
    */
   public void update(PodStatusUpdated event) {
-    logger.info("Updating slave for pod {}", event.id().value());
     if (event.newStatus().isDefined()) {
       logger.info("Received new status for {}", event.id().value());
       this.currentStatus = Optional.of(event.newStatus().get());

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -1,22 +1,42 @@
 package org.jenkinsci.plugins.mesos;
 
-import com.mesosphere.usi.core.models.PodStateEvent;
+import com.mesosphere.usi.core.models.PodStatus;
+import com.mesosphere.usi.core.models.PodStatusUpdated;
 import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.EphemeralNode;
+import hudson.slaves.JNLPLauncher;
+import hudson.slaves.NodeProperty;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang.NotImplementedException;
 
 /** Representation of a Jenkins node on Mesos. */
 public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
 
-  public MesosSlave() throws Descriptor.FormException, IOException {
-    super(null, null, null, null, null, null, null, null, null);
-    throw new NotImplementedException();
+  Optional<PodStatus> currentStatus = Optional.empty();
+
+  public MesosSlave(
+      String name,
+      String nodeDescription,
+      String labelString,
+      List<? extends NodeProperty<?>> nodeProperties)
+      throws Descriptor.FormException, IOException {
+    super(
+        name,
+        nodeDescription,
+        null,
+        1,
+        null,
+        labelString,
+        new JNLPLauncher(),
+        null,
+        nodeProperties);
   }
 
   /**
@@ -34,7 +54,11 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
    *
    * @param event The state event from USI which informs about the task status.
    */
-  public void update(PodStateEvent event) {}
+  public void update(PodStatusUpdated event) {
+    if (event.newStatus().isDefined()) {
+      this.currentStatus = Optional.of(event.newStatus().get());
+    }
+  }
 
   @Override
   public Node asNode() {

--- a/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
@@ -35,8 +35,8 @@ class ConnectionTest {
 
     MesosSlave agent = api.enqueueAgent().toCompletableFuture().get();
 
-    boolean running = agent.currentStatus.isPresent();
-    while (!running) {
+    // Poll state until we get something.
+    while (!agent.isRunning()) {
       Thread.sleep(1000);
       System.out.println("not running yet");
     }

--- a/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
@@ -4,10 +4,14 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import com.mesosphere.utils.mesos.MesosClusterExtension;
 import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
+import hudson.model.Descriptor.FormException;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(TestUtils.JenkinsParameterResolver.class)
 class ConnectionTest {
 
   @RegisterExtension static ZookeeperServerExtension zkServer = new ZookeeperServerExtension();
@@ -23,9 +27,18 @@ class ConnectionTest {
           .build(system, materializer);
 
   @Test
-  public void connectMesosApi() throws InterruptedException, ExecutionException {
+  public void startAgent(TestUtils.JenkinsRule j)
+      throws InterruptedException, ExecutionException, IOException, FormException {
 
     String mesosUrl = mesosCluster.getMesosUrl();
-    new MesosApi(mesosUrl, "example", "MesosTest");
+    MesosApi api = new MesosApi(mesosUrl, "example", "MesosTest");
+
+    MesosSlave agent = api.enqueueAgent().toCompletableFuture().get();
+
+    boolean running = agent.currentStatus.isPresent();
+    while (!running) {
+      Thread.sleep(1000);
+      System.out.println("not running yet");
+    }
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/TestUtils.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/TestUtils.java
@@ -1,0 +1,65 @@
+package org.jenkinsci.plugins.mesos;
+
+import java.util.Optional;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.jvnet.hudson.test.JenkinsRecipe;
+
+// Copied from https://issues.jenkins-ci.org/browse/JENKINS-48466
+public class TestUtils {
+  public static class JenkinsRule extends org.jvnet.hudson.test.JenkinsRule {
+    private final ParameterContext context;
+
+    JenkinsRule(ParameterContext context) {
+      this.context = context;
+    }
+
+    @Override
+    public void recipe() throws Exception {
+      Optional<JenkinsRecipe> a = context.findAnnotation(JenkinsRecipe.class);
+      if (!a.isPresent()) return;
+      final JenkinsRecipe.Runner runner = a.get().value().newInstance();
+      recipes.add(runner);
+      tearDowns.add(() -> runner.tearDown(this, a.get()));
+    }
+  }
+
+  public static class JenkinsParameterResolver implements ParameterResolver, AfterEachCallback {
+    private static final String key = "jenkins-instance";
+    private static final ExtensionContext.Namespace ns =
+        ExtensionContext.Namespace.create(JenkinsParameterResolver.class);
+
+    @Override
+    public boolean supportsParameter(
+        ParameterContext parameterContext, ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+      return parameterContext.getParameter().getType().equals(JenkinsRule.class);
+    }
+
+    @Override
+    public Object resolveParameter(
+        ParameterContext parameterContext, ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+      JenkinsRule instance =
+          extensionContext
+              .getStore(ns)
+              .getOrComputeIfAbsent(
+                  key, key -> new JenkinsRule(parameterContext), JenkinsRule.class);
+      try {
+        instance.before();
+        return instance;
+      } catch (Throwable t) {
+        throw new ParameterResolutionException(t.toString());
+      }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+      JenkinsRule rule = context.getStore(ns).remove(key, JenkinsRule.class);
+      if (rule != null) rule.after();
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Uses the USI Java API to start a simple sleeping task. An integration test waits
for the task to be running.

Is blocked by mesosphere/usi#79.

Co-authored-by: Karsten Jeschkies <k@jeschkies.xyz>