### PR TITLE
Fetch agent jar from Jenkins master.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,11 @@ ext {
 dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
-
-    // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'com.google.guava:guava:26.0-jre'
-    implementation('com.mesosphere.usi:core') { version { branch = usiBranch } }
-    implementation('com.mesosphere.usi:core-models') { version { branch = usiBranch } }
-    implementation('com.mesosphere.usi:mesos-client') { version { branch = usiBranch } }
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
+    api 'com.google.guava:guava:26.0-jre'
+    api ('com.mesosphere.usi:core') { version { branch = usiBranch } }
+    api ('com.mesosphere.usi:core-models') { version { branch = usiBranch } }
+    api ('com.mesosphere.usi:mesos-client') { version { branch = usiBranch } }
+    api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
 
     // Test dependencies
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     testImplementation('com.mesosphere.usi:test-utils') { version { branch = usiBranch } }
+    testImplementation 'org.awaitility:awaitility:3.1.6'
 }
 
 test {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -12,13 +12,12 @@ import com.mesosphere.mesos.client.MesosClient$;
 import com.mesosphere.mesos.conf.MesosClientSettings;
 import com.mesosphere.usi.core.japi.Scheduler;
 import com.mesosphere.usi.core.models.*;
-import com.mesosphere.usi.core.models.Goal.Running$;
-import com.mesosphere.usi.core.models.resources.ScalarRequirement;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import hudson.model.Descriptor.FormException;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -28,8 +27,6 @@ import org.apache.mesos.v1.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
 import scala.concurrent.ExecutionContext;
 
 public class MesosApi {
@@ -142,12 +139,12 @@ public class MesosApi {
    *
    * @return a {@link MesosSlave} once it's queued for running.
    */
-  public CompletionStage<MesosSlave> enqueueAgent() throws IOException, FormException {
-    PodSpec spec = buildMesosAgentTask(0.1, 32);
+  public CompletionStage<MesosSlave> enqueueAgent()
+      throws IOException, FormException, URISyntaxException {
+    var name = String.format("jenkins-test-%s", UUID.randomUUID().toString());
+    MesosSlave mesosSlave = new MesosSlave(name, "Mesos Jenkins Slave", "label", List.of());
+    PodSpec spec = mesosSlave.getPodSpec(0.1, 32);
     SpecUpdated update = new PodSpecUpdated(spec.id(), Option.apply(spec));
-
-    MesosSlave mesosSlave =
-        new MesosSlave(spec.id().value(), "Mesos Jenkins Slave", "label", List.of());
 
     stateMap.put(spec.id(), mesosSlave);
 
@@ -175,21 +172,6 @@ public class MesosApi {
         .toCompletableFuture();
   }
 
-  private PodSpec buildMesosAgentTask(double cpu, double mem) {
-    var role = "jenkins";
-    RunSpec spec =
-        new RunSpec(
-            convertListToSeq(
-                Arrays.asList(ScalarRequirement.cpus(cpu), ScalarRequirement.memory(mem))),
-            "echo Hello! && sleep 1000000",
-            role,
-            convertListToSeq(Collections.emptyList()));
-    String id = UUID.randomUUID().toString();
-    PodSpec podSpec =
-        new PodSpec(new PodId(String.format("jenkins-test-%s", id)), Running$.MODULE$, spec);
-    return podSpec;
-  }
-
   /**
    * Callback for USI to process state events.
    *
@@ -209,9 +191,5 @@ public class MesosApi {
             return slave;
           });
     }
-  }
-
-  private <T> Seq<T> convertListToSeq(List<T> inputList) {
-    return JavaConverters.asScalaIteratorConverter(inputList.iterator()).asScala().toSeq();
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -4,6 +4,8 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.slaves.AbstractCloudImpl;
 import hudson.slaves.NodeProvisioner;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -23,14 +25,17 @@ class MesosCloud extends AbstractCloudImpl {
 
   private MesosApi mesos;
   private final String frameworkName = "JenkinsMesos";
-  private final String slavesUser = "example";
+  private final String slavesUser = System.getProperty("user.name");
+  private final URL jenkinsUrl;
 
   @DataBoundConstructor
-  public MesosCloud(String name) throws InterruptedException, ExecutionException {
+  public MesosCloud(String name, String mesosUrl, String jenkinsUrl)
+      throws InterruptedException, ExecutionException, MalformedURLException {
     super(name, null);
 
-    String masterUrl = null;
-    mesos = new MesosApi(masterUrl, slavesUser, frameworkName);
+    this.jenkinsUrl = new URL(jenkinsUrl);
+
+    mesos = new MesosApi(mesosUrl, this.jenkinsUrl, slavesUser, frameworkName);
     throw new NotImplementedException();
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -1,13 +1,8 @@
 package org.jenkinsci.plugins.mesos;
 
-import com.mesosphere.usi.core.models.FetchUri;
-import com.mesosphere.usi.core.models.Goal.Running$;
-import com.mesosphere.usi.core.models.PodId;
 import com.mesosphere.usi.core.models.PodSpec;
 import com.mesosphere.usi.core.models.PodStatus;
 import com.mesosphere.usi.core.models.PodStatusUpdated;
-import com.mesosphere.usi.core.models.RunSpec;
-import com.mesosphere.usi.core.models.resources.ScalarRequirement;
 import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.model.TaskListener;
@@ -17,20 +12,17 @@ import hudson.slaves.EphemeralNode;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.NodeProperty;
 import java.io.IOException;
-import java.net.URI;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.mesos.v1.Protos.TaskState;
+import org.jenkinsci.plugins.mesos.api.MesosSlavePodSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
 
 /** Representation of a Jenkins node on Mesos. */
 public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
@@ -85,6 +77,16 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
     }
   }
 
+  public PodSpec getPodSpec(Double cpu, int memory)
+      throws MalformedURLException, URISyntaxException {
+    return MesosSlavePodSpec.builder()
+        .withCpu(cpu)
+        .withMemory(memory)
+        .withName(this.name)
+        .withJenkinsUrl(this.jenkinsUrl)
+        .build();
+  }
+
   /**
    * Updates the state of the slave.
    *
@@ -95,25 +97,6 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
       logger.info("Received new status for {}", event.id().value());
       this.currentStatus = Optional.of(event.newStatus().get());
     }
-  }
-
-  public PodSpec getPodSpec(double cpu, double mem) throws URISyntaxException {
-    final var role = "test";
-    final var uri = new URI(jenkinsUrl + "/jnlpJars/agent.jar");
-    final var fetchUri = new FetchUri(uri, false, false, false, Option.empty());
-    RunSpec spec =
-        new RunSpec(
-            convertListToSeq(
-                Arrays.asList(ScalarRequirement.cpus(cpu), ScalarRequirement.memory(mem))),
-            "echo hello && ls -lah ${MESOS_SANDBOX-.} && java -version && ${MESOS_SANDBOX-.}/agent.jar --help",
-            role,
-            convertListToSeq(List.of(fetchUri)));
-    PodSpec podSpec = new PodSpec(new PodId(this.name), Running$.MODULE$, spec);
-    return podSpec;
-  }
-
-  private <T> Seq<T> convertListToSeq(List<T> inputList) {
-    return JavaConverters.asScalaIteratorConverter(inputList.iterator()).asScala().toSeq();
   }
 
   @Override

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/MesosSlavePodSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/MesosSlavePodSpec.java
@@ -31,8 +31,8 @@ public class MesosSlavePodSpec {
 
     private static final String AGENT_JAR_URI_SUFFIX = "jnlpJars/agent.jar";
 
-    // We allocate 10% more memory to the Mesos task to account for the JVM overhead.
-    private static final double JVM_MEM_OVERHEAD_FACTOR = 1.1;
+    // We allocate extra memory for the JVM
+    private static final int JVM_XMX = 32;
 
     private static final String AGENT_COMMAND_FORMAT =
         "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s";
@@ -73,8 +73,8 @@ public class MesosSlavePodSpec {
      * @return the pod spec builder.
      */
     public Builder withMemory(int memory) {
-      this.memory = ScalarRequirement.memory(memory * JVM_MEM_OVERHEAD_FACTOR);
-      this.xmx = memory;
+      this.memory = ScalarRequirement.memory(memory + JVM_XMX);
+      this.xmx = JVM_XMX;
       return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/MesosSlavePodSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/MesosSlavePodSpec.java
@@ -1,0 +1,133 @@
+package org.jenkinsci.plugins.mesos.api;
+
+import com.mesosphere.usi.core.models.FetchUri;
+import com.mesosphere.usi.core.models.Goal.Running$;
+import com.mesosphere.usi.core.models.PodId;
+import com.mesosphere.usi.core.models.PodSpec;
+import com.mesosphere.usi.core.models.RunSpec;
+import com.mesosphere.usi.core.models.resources.ScalarRequirement;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
+import scala.Option;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+public class MesosSlavePodSpec {
+
+  private MesosSlavePodSpec() {}
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * A simpler factory for building {@link com.mesosphere.usi.core.models.PodSpec} for Jenkins
+   * agents.
+   */
+  public static class Builder {
+
+    private static final String AGENT_JAR_URI_SUFFIX = "jnlpJars/agent.jar";
+
+    // We allocate 10% more memory to the Mesos task to account for the JVM overhead.
+    private static final double JVM_MEM_OVERHEAD_FACTOR = 1.1;
+
+    private static final String AGENT_COMMAND_FORMAT =
+        "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s";
+
+    private PodId id = null;
+    private ScalarRequirement cpus = null;
+    private ScalarRequirement memory = null;
+    private String role = "test";
+
+    private int xmx = 0;
+
+    private String jvmArgString = "";
+    private String jnlpArgString = "";
+
+    private URL jenkinsMaster = null;
+
+    /**
+     * Sets the name of the Mesos task.
+     *
+     * @param name Unique name of Mesos task.
+     * @return this pod spec builder.
+     */
+    public Builder withName(String name) {
+      this.id = new PodId(name);
+      return this;
+    }
+
+    public Builder withCpu(Double cpus) {
+      this.cpus = ScalarRequirement.cpus(cpus);
+      return this;
+    }
+
+    /**
+     * Sets the maximum memory pool for the JVM aka Xmx. Please note that the Mesos task will have
+     * {@link Builder#JVM_MEM_OVERHEAD_FACTOR} more memory allocated.
+     *
+     * @param memory Memory in megabyte.
+     * @return the pod spec builder.
+     */
+    public Builder withMemory(int memory) {
+      this.memory = ScalarRequirement.memory(memory * JVM_MEM_OVERHEAD_FACTOR);
+      this.xmx = memory;
+      return this;
+    }
+
+    public Builder withJenkinsUrl(URL url) {
+      this.jenkinsMaster = url;
+      return this;
+    }
+
+    public Builder withRole(String role) {
+      this.role = role;
+      return this;
+    }
+
+    public PodSpec build() throws MalformedURLException, URISyntaxException {
+      final var runSpec =
+          new RunSpec(
+              convertListToSeq(List.of(this.cpus, this.memory)),
+              this.buildCommand(),
+              this.role,
+              convertListToSeq(List.of(buildFetchUri())));
+      return new PodSpec(this.id, Running$.MODULE$, runSpec);
+    }
+
+    /** @return the agent shell command for the Mesos task. */
+    private String buildCommand() throws MalformedURLException {
+      return String.format(
+          AGENT_COMMAND_FORMAT,
+          this.xmx,
+          this.jvmArgString,
+          this.jnlpArgString,
+          buildJnlpSecret(),
+          buildJnlpUrl());
+    }
+
+    private String buildJnlpSecret() {
+      return ""; // TODO
+      // https://github.com/mesosphere/mesos-plugin/blob/master/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java#L232
+    }
+
+    /** @return the Jnlp url for the agent: http://[master]/computer/[slaveName]/slave-agent.jnlp */
+    private URL buildJnlpUrl() throws MalformedURLException {
+      final String path = Paths.get("computer", this.id.value(), "slave-agent.jnlp").toString();
+      return new URL(this.jenkinsMaster, path);
+    }
+
+    /** @return the {@link FetchUri} for the Jenkins agent jar file. */
+    private FetchUri buildFetchUri() throws MalformedURLException, URISyntaxException {
+      final var uri = new URL(this.jenkinsMaster, AGENT_JAR_URI_SUFFIX).toURI();
+      return new FetchUri(uri, false, false, false, Option.empty());
+    }
+
+    private <T> Seq<T> convertListToSeq(List<T> inputList) {
+      return JavaConverters.asScalaIteratorConverter(inputList.iterator()).asScala().toSeq();
+    }
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
@@ -37,7 +37,7 @@ class ConnectionTest {
     var jenkinsUrl = j.getURL();
 
     String mesosUrl = mesosCluster.getMesosUrl();
-    MesosApi api = new MesosApi(mesosUrl, jenkinsUrl, "example", "MesosTest");
+    MesosApi api = new MesosApi(mesosUrl, jenkinsUrl, System.getProperty("user.name"), "MesosTest");
 
     MesosSlave agent = api.enqueueAgent().toCompletableFuture().get();
 

--- a/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
@@ -6,7 +6,10 @@ import com.mesosphere.utils.mesos.MesosClusterExtension;
 import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
 import hudson.model.Descriptor.FormException;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -28,17 +31,14 @@ class ConnectionTest {
 
   @Test
   public void startAgent(TestUtils.JenkinsRule j)
-      throws InterruptedException, ExecutionException, IOException, FormException {
+      throws InterruptedException, ExecutionException, IOException, FormException,
+          URISyntaxException {
 
     String mesosUrl = mesosCluster.getMesosUrl();
     MesosApi api = new MesosApi(mesosUrl, "example", "MesosTest");
 
     MesosSlave agent = api.enqueueAgent().toCompletableFuture().get();
 
-    // Poll state until we get something.
-    while (!agent.isRunning()) {
-      Thread.sleep(1000);
-      System.out.println("not running yet");
-    }
+    Awaitility.await().atMost(1, TimeUnit.SECONDS).until(agent::isRunning);
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/ConnectionTest.java
@@ -34,8 +34,10 @@ class ConnectionTest {
       throws InterruptedException, ExecutionException, IOException, FormException,
           URISyntaxException {
 
+    var jenkinsUrl = j.getURL();
+
     String mesosUrl = mesosCluster.getMesosUrl();
-    MesosApi api = new MesosApi(mesosUrl, "example", "MesosTest");
+    MesosApi api = new MesosApi(mesosUrl, jenkinsUrl, "example", "MesosTest");
 
     MesosSlave agent = api.enqueueAgent().toCompletableFuture().get();
 

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
@@ -1,4 +1,4 @@
-package org.jenkinsci.plugins.mesos;
+package org.jenkinsci.plugins.mesos.integration;
 
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
@@ -10,12 +10,16 @@ import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
+import org.jenkinsci.plugins.mesos.MesosApi;
+import org.jenkinsci.plugins.mesos.MesosSlave;
+import org.jenkinsci.plugins.mesos.TestUtils.JenkinsParameterResolver;
+import org.jenkinsci.plugins.mesos.TestUtils.JenkinsRule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(TestUtils.JenkinsParameterResolver.class)
-class ConnectionTest {
+@ExtendWith(JenkinsParameterResolver.class)
+class MesosApiTest {
 
   @RegisterExtension static ZookeeperServerExtension zkServer = new ZookeeperServerExtension();
 
@@ -26,11 +30,11 @@ class ConnectionTest {
   static MesosClusterExtension mesosCluster =
       MesosClusterExtension.builder()
           .withMesosMasterUrl(String.format("zk://%s/mesos", zkServer.getConnectionUrl()))
-          .withLogPrefix(ConnectionTest.class.getCanonicalName())
+          .withLogPrefix(MesosApiTest.class.getCanonicalName())
           .build(system, materializer);
 
   @Test
-  public void startAgent(TestUtils.JenkinsRule j)
+  public void startAgent(JenkinsRule j)
       throws InterruptedException, ExecutionException, IOException, FormException,
           URISyntaxException {
 


### PR DESCRIPTION
Summary:
This patch refactors `MesosSlave` and `MesosApi` to start the actual Jenkins
agent jar as a Mesos task. Mesos will fetch the jar from the Jenkins test fixture
and start it with similar parameters as the original plugin.

We also import `Awaitility` to wait for an assertion. 