### PR TITLE
Tie MesosComputer to the underlying Mesos Task

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -20,11 +20,11 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
   private final int idleTerminationMinutes;
 
   @DataBoundConstructor
-  public MesosAgentSpecTemplate(String label, Node.Mode mode, String idleTerminationMinutes) {
+  public MesosAgentSpecTemplate(String label, Node.Mode mode) {
     this.label = label;
     this.labelSet = Label.parse(label);
     this.mode = mode;
-    this.idleTerminationMinutes = Integer.parseInt(idleTerminationMinutes);
+    this.idleTerminationMinutes = 1;
   }
 
   @Extension

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -8,7 +8,6 @@ import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import java.util.Set;
 import java.util.UUID;
-
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** This is the Mesos agent pod spec config set by a user. */

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -8,6 +8,8 @@ import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import java.util.Set;
 import java.util.UUID;
+
+import org.apache.xpath.operations.Bool;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** This is the Mesos agent pod spec config set by a user. */
@@ -63,5 +65,9 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
 
   public int getIdleTerminationMinutes() {
     return idleTerminationInMinutes;
+  }
+
+  public Boolean getReusable() {
+    return true;
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -17,14 +17,14 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
   private final Set<LabelAtom> labelSet;
 
   private final Node.Mode mode;
-  private final int idleTerminationInMinutes;
+  private final int idleTerminationMinutes;
 
   @DataBoundConstructor
   public MesosAgentSpecTemplate(String label, Node.Mode mode, String idleTerminationMinutes) {
     this.label = label;
     this.labelSet = Label.parse(label);
     this.mode = mode;
-    this.idleTerminationInMinutes = Integer.parseInt(idleTerminationMinutes);
+    this.idleTerminationMinutes = Integer.parseInt(idleTerminationMinutes);
   }
 
   @Extension
@@ -62,7 +62,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
   }
 
   public int getIdleTerminationMinutes() {
-    return idleTerminationInMinutes;
+    return idleTerminationMinutes;
   }
 
   public Boolean getReusable() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -9,7 +9,6 @@ import hudson.model.labels.LabelAtom;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.xpath.operations.Bool;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** This is the Mesos agent pod spec config set by a user. */

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -51,8 +51,6 @@ public class MesosApi {
 
   @XStreamOmitField private final ExecutionContext context;
 
-  private final Integer IDLE_TERMINATION_IN_MIN = 1;
-
   /**
    * Establishes a connection to Mesos and provides a simple interface to start and stop {@link
    * MesosJenkinsAgent} instances.

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -45,7 +45,7 @@ public class MesosApi {
   private final ActorMaterializer materializer;
   private final ExecutionContext context;
 
-  private final Integer idleTimeoutInMinutes = 5;
+  private final Integer IDLE_TERMINATION_IN_MIN = 5;
 
   /**
    * Establishes a connection to Mesos and provides a simple interface to start and stop {@link
@@ -137,7 +137,7 @@ public class MesosApi {
             "Mesos Jenkins Slave",
             jenkinsUrl,
             "label",
-            idleTimeoutInMinutes,
+            IDLE_TERMINATION_IN_MIN,
             List.of());
     PodSpec spec = mesosSlave.getPodSpec(cpu, mem, Goal.Running$.MODULE$);
     SpecUpdated update = new PodSpecUpdated(spec.id(), Option.apply(spec));

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -148,7 +148,7 @@ public class MesosApi {
             "Mesos Jenkins Slave",
             jenkinsUrl,
             spec.getIdleTerminationMinutes(),
-            true,
+            spec.getReusable(),
             Collections.emptyList());
     PodSpec podSpec = mesosJenkinsAgent.getPodSpec(Goal.Running$.MODULE$);
     SpecUpdated update = new PodSpecUpdated(podSpec.id(), Option.apply(podSpec));

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -45,6 +45,8 @@ public class MesosApi {
   private final ActorMaterializer materializer;
   private final ExecutionContext context;
 
+  private final Integer idleTimeoutInMinutes = 5;
+
   /**
    * Establishes a connection to Mesos and provides a simple interface to start and stop {@link
    * MesosSlave} instances.
@@ -129,7 +131,14 @@ public class MesosApi {
 
     var name = String.format("jenkins-test-%s", UUID.randomUUID().toString());
     MesosSlave mesosSlave =
-        new MesosSlave(cloud, name, "Mesos Jenkins Slave", jenkinsUrl, "label", List.of());
+        new MesosSlave(
+            cloud,
+            name,
+            "Mesos Jenkins Slave",
+            jenkinsUrl,
+            "label",
+            idleTimeoutInMinutes,
+            List.of());
     PodSpec spec = mesosSlave.getPodSpec(cpu, mem, Goal.Running$.MODULE$);
     SpecUpdated update = new PodSpecUpdated(spec.id(), Option.apply(spec));
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -45,7 +45,7 @@ public class MesosApi {
   private final ActorMaterializer materializer;
   private final ExecutionContext context;
 
-  private final Integer IDLE_TERMINATION_IN_MIN = 5;
+  private final Integer IDLE_TERMINATION_IN_MIN = 1;
 
   /**
    * Establishes a connection to Mesos and provides a simple interface to start and stop {@link
@@ -138,6 +138,7 @@ public class MesosApi {
             jenkinsUrl,
             "label",
             IDLE_TERMINATION_IN_MIN,
+            true,
             List.of());
     PodSpec spec = mesosSlave.getPodSpec(cpu, mem, Goal.Running$.MODULE$);
     SpecUpdated update = new PodSpecUpdated(spec.id(), Option.apply(spec));

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -28,6 +28,13 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
   @Override
   public void taskAccepted(Executor executor, Queue.Task task) {
     super.taskAccepted(executor, task);
+    if (!reusable) {
+      // single use computer will only accept one task, after completing task it will go idle and be
+      // killed by MesosRetentionStrategy
+      logger.warn(
+          " Computer " + this + ": is no longer accepting tasks and was marked as single-use");
+      setAcceptingTasks(false);
+    }
     logger.info(" Computer " + this + ": task accepted");
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -66,7 +66,7 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
     try {
       getNode().terminate();
     } catch (InterruptedException e) {
-      logger.warn(" got exception " + e + "failure to delete agent" + getNode().getPodId());
+      logger.warn("Failure to terminate agent {}", getNode().getPodId(), e);
     }
     return new HttpRedirect("..");
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.mesos;
 import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
+import java.io.IOException;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.slf4j.Logger;
@@ -54,11 +55,11 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
   }
 
   @Override
-  public HttpResponse doDoDelete() {
+  public HttpResponse doDoDelete() throws IOException {
     try {
       getNode().terminate();
-    } catch (Exception e) {
-      logger.warn("Error killing " + getNode().getPodId());
+    } catch (InterruptedException e) {
+      logger.warn(" got exception " + e + "failure to delete agent" + getNode().getPodId());
     }
     return new HttpRedirect("..");
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -8,6 +8,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.kohsuke.stapler.HttpResponse;
 
+import java.io.IOException;
+
 /** The running state of a {@link hudson.model.Node} or rather {@link MesosSlave} in our case. */
 public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
 
@@ -51,5 +53,15 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
   @Override
   public MesosSlave getNode() {
     return super.getNode();
+  }
+
+  @Override
+  public HttpResponse doDoDelete() {
+    try {
+      getNode().terminate();
+    } catch (Exception e) {
+      logger.warn("Error killing " + getNode().getPodId());
+    }
+    return HttpRedirect{".."};
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -3,8 +3,10 @@ package org.jenkinsci.plugins.mesos;
 import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
+import org.kohsuke.stapler.HttpRedirect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.kohsuke.stapler.HttpResponse;
 
 /** The running state of a {@link hudson.model.Node} or rather {@link MesosSlave} in our case. */
 public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
@@ -44,5 +46,10 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
   @Override
   public String toString() {
     return String.format("%s (slave: %s)", getName(), getNode());
+  }
+
+  @Override
+  public MesosSlave getNode() {
+    return super.getNode();
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -4,11 +4,9 @@ import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
 import org.kohsuke.stapler.HttpRedirect;
+import org.kohsuke.stapler.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.kohsuke.stapler.HttpResponse;
-
-import java.io.IOException;
 
 /** The running state of a {@link hudson.model.Node} or rather {@link MesosSlave} in our case. */
 public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
@@ -62,6 +60,6 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
     } catch (Exception e) {
       logger.warn("Error killing " + getNode().getPodId());
     }
-    return HttpRedirect{".."};
+    return new HttpRedirect("..");
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -34,8 +34,7 @@ public class MesosComputer extends AbstractCloudComputer<MesosJenkinsAgent> {
     if (!reusable) {
       // single use computer will only accept one task, after completing task it will go idle and be
       // killed by MesosRetentionStrategy
-      logger.warn(
-          " Computer " + this + ": is no longer accepting tasks and was marked as single-use");
+      logger.info("Computer {}: is no longer accepting tasks and was marked as single-use", this);
       setAcceptingTasks(false);
     }
     logger.info("Computer {}: task accepted", this);

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -4,7 +4,7 @@ import hudson.model.Descriptor;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
 
-/**  A strategy to terminate idle {@link MesosComputer} */
+/** A strategy to terminate idle {@link MesosComputer} */
 public class MesosRetentionStrategy extends CloudRetentionStrategy {
   /**
    * Constructs a new {@link hudson.slaves.CloudRetentionStrategy}. This is called by {@link

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -4,6 +4,7 @@ import hudson.model.Descriptor;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
 
+/**  A strategy to terminate idle {@link MesosComputer} */
 public class MesosRetentionStrategy extends CloudRetentionStrategy {
   /**
    * Constructs a new {@link hudson.slaves.CloudRetentionStrategy}. This is called by {@link

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -5,7 +5,13 @@ import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
 
 public class MesosRetentionStrategy extends CloudRetentionStrategy {
-
+  /**
+   * Constructs a new {@link hudson.slaves.CloudRetentionStrategy}. This is called by {@link
+   * MesosSlave()}.
+   *
+   * @param idleMinutes The number of minutes to wait before calling getNode().terminate() on an
+   *     idle {@link MesosComputer}
+   */
   public MesosRetentionStrategy(int idleMinutes) {
     super(idleMinutes);
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.mesos;
+
+import hudson.model.Descriptor;
+import hudson.slaves.CloudRetentionStrategy;
+import hudson.slaves.RetentionStrategy;
+
+public class MesosRetentionStrategy extends CloudRetentionStrategy {
+
+  public MesosRetentionStrategy(int idleMinutes) {
+    super(idleMinutes);
+  }
+
+  public static class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
+    @Override
+    public String getDisplayName() {
+      return "Mesos Retention Strategy";
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -51,6 +51,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
       String nodeDescription,
       URL jenkinsUrl,
       String labelString,
+      Integer idleTerminationInMinutes,
       List<? extends NodeProperty<?>> nodeProperties)
       throws Descriptor.FormException, IOException {
     super(
@@ -61,7 +62,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
         Mode.NORMAL,
         labelString,
         new JNLPLauncher(),
-        null,
+        new MesosRetentionStrategy(idleTerminationInMinutes),
         nodeProperties);
     // pass around the MesosApi connection via MesosCloud
     this.cloud = cloud;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -52,6 +52,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
       URL jenkinsUrl,
       String labelString,
       Integer idleTerminationInMinutes,
+      Boolean reusable,
       List<? extends NodeProperty<?>> nodeProperties)
       throws Descriptor.FormException, IOException {
     super(
@@ -66,7 +67,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
         nodeProperties);
     // pass around the MesosApi connection via MesosCloud
     this.cloud = cloud;
-    this.reusable = true;
+    this.reusable = reusable;
     this.podId = id;
     this.jenkinsUrl = jenkinsUrl;
   }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
@@ -53,7 +53,7 @@ class MesosApiTest {
 
     final String name = "jenkins-start-agent";
     final String idleMin = "1";
-    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE, idleMin);
+    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE);
     MesosJenkinsAgent agent = api.enqueueAgent(null, name, spec).toCompletableFuture().get();
 
     Awaitility.await().atMost(5, TimeUnit.MINUTES).until(agent::isRunning);
@@ -69,7 +69,7 @@ class MesosApiTest {
 
     final String name = "jenkins-stop-agent";
     final String idleMin = "1";
-    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE, idleMin);
+    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE);
     MesosJenkinsAgent agent = api.enqueueAgent(null, name, spec).toCompletableFuture().get();
     // Poll state until we get something.
     await().atMost(5, TimeUnit.MINUTES).until(agent::isRunning);

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
@@ -66,7 +66,7 @@ public class MesosCloudProvisionTest {
 
     MesosSlave agent = (MesosSlave) cloud.startAgent().get();
 
-    await().atMost(5, TimeUnit.MINUTES).until(agent::isRunning);
+    await().atMost(10, TimeUnit.SECONDS).until(agent::isRunning);
 
     assertThat(agent.isRunning(), is(true));
     assertThat(agent.toComputer().isOnline(), is(true));

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
@@ -52,6 +52,7 @@ public class MesosCloudProvisionTest {
 
       // ensure all plannedNodes are now running
       assertThat(agent.isRunning(), is(true));
+      assertThat(agent.getComputer().isOnline(), is(true));
     }
 
     // check that jenkins knows about all the plannedNodes

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
@@ -53,7 +53,7 @@ public class MesosCloudProvisionTest {
     LabelAtom label = new LabelAtom("label");
     final String idleMin = "1";
     final MesosAgentSpecTemplate spec =
-        new MesosAgentSpecTemplate(label.toString(), Mode.EXCLUSIVE, idleMin);
+        new MesosAgentSpecTemplate(label.toString(), Mode.EXCLUSIVE);
     List<MesosAgentSpecTemplate> specTemplates = Collections.singletonList(spec);
 
     MesosCloud cloud =
@@ -86,7 +86,7 @@ public class MesosCloudProvisionTest {
   public void testStartAgent(TestUtils.JenkinsRule j) throws Exception {
     final String name = "jenkins-agent";
     final String idleMin = "1";
-    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE, idleMin);
+    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE);
     List<MesosAgentSpecTemplate> specTemplates = Collections.singletonList(spec);
     MesosCloud cloud =
         new MesosCloud(

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
@@ -50,7 +50,7 @@ public class MesosJenkinsAgentLifecycleTest {
 
     final String name = "jenkins-lifecycle";
     final String idleMin = "1";
-    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE, idleMin);
+    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE);
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
     agent.waitUntilOnlineAsync().get();
 
@@ -79,7 +79,7 @@ public class MesosJenkinsAgentLifecycleTest {
 
     final String name = "jenkins-node-terminate";
     final String idleMin = "1";
-    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE, idleMin);
+    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE);
 
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
     agent.waitUntilOnlineAsync().get();
@@ -106,7 +106,7 @@ public class MesosJenkinsAgentLifecycleTest {
 
     final String name = "jenkins-node-delete";
     final String idleMin = "1";
-    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE, idleMin);
+    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE);
 
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
     agent.waitUntilOnlineAsync().get();
@@ -133,7 +133,7 @@ public class MesosJenkinsAgentLifecycleTest {
 
     final String name = "jenkins-node-delete";
     final String idleMin = "1";
-    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE, idleMin);
+    final MesosAgentSpecTemplate spec = new MesosAgentSpecTemplate(name, Mode.EXCLUSIVE);
 
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
     agent.waitUntilOnlineAsync().get();

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
@@ -97,7 +97,7 @@ public class MesosSlaveLifecycleTest {
     assertThat(agent.getComputer().isOnline(), is(true));
     assertThat(agent.getComputer().isIdle(), is(true));
 
-    //after 1 minute MesosRetentionStrategy will kill the task
+    // after 1 minute MesosRetentionStrategy will kill the task
     await().atMost(2, TimeUnit.MINUTES).until(agent::isKilled);
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
@@ -85,4 +85,19 @@ public class MesosSlaveLifecycleTest {
     await().atMost(10, TimeUnit.SECONDS).until(agent::isKilled);
     assertThat(agent.isKilled(), is(true));
   }
+
+  @Test
+  public void testRetentionStrategy(TestUtils.JenkinsRule j) throws Exception {
+    MesosCloud cloud = new MesosCloud("mesos", mesosCluster.getMesosUrl(), j.getURL().toString());
+
+    MesosSlave agent = (MesosSlave) cloud.startAgent().get();
+    agent.waitUntilOnlineAsync().get();
+
+    assertThat(agent.isRunning(), is(true));
+    assertThat(agent.getComputer().isOnline(), is(true));
+    assertThat(agent.getComputer().isIdle(), is(true));
+
+    //after 1 minute MesosRetentionStrategy will kill the task
+    await().atMost(2, TimeUnit.MINUTES).until(agent::isKilled);
+  }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
@@ -98,6 +98,6 @@ public class MesosSlaveLifecycleTest {
     assertThat(agent.getComputer().isIdle(), is(true));
 
     // after 1 minute MesosRetentionStrategy will kill the task
-    await().atMost(2, TimeUnit.MINUTES).until(agent::isKilled);
+    await().atMost(3, TimeUnit.MINUTES).until(agent::isKilled);
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
@@ -48,7 +48,7 @@ public class MesosSlaveLifecycleTest {
     assertThat(Jenkins.getInstanceOrNull().getNodes(), hasSize(1));
 
     agent.terminate();
-    await().atMost(5, TimeUnit.MINUTES).until(agent::isKilled);
+    await().atMost(10, TimeUnit.SECONDS).until(agent::isKilled);
     assertThat(agent.isKilled(), is(true));
 
     assertThat(Jenkins.getInstanceOrNull().getNodes(), hasSize(0));
@@ -66,7 +66,7 @@ public class MesosSlaveLifecycleTest {
 
     MesosSlave shouldBeParent = (MesosSlave) agent.getComputer().getNode();
     shouldBeParent.terminate();
-    await().atMost(5, TimeUnit.MINUTES).until(agent::isKilled);
+    await().atMost(10, TimeUnit.SECONDS).until(agent::isKilled);
     assertThat(agent.isKilled(), is(true));
   }
 
@@ -82,7 +82,7 @@ public class MesosSlaveLifecycleTest {
 
     agent.getComputer().doDoDelete();
 
-    await().atMost(5, TimeUnit.MINUTES).until(agent::isKilled);
+    await().atMost(10, TimeUnit.SECONDS).until(agent::isKilled);
     assertThat(agent.isKilled(), is(true));
   }
 }


### PR DESCRIPTION
DCOS_OSS-5045

Summary:
- Introduce a simple strategy that will kill offline MesosComputer after 1 minute
- Allow MesosComputer termination to terminate the parent node and kill the mesos task

Extension of the CloudRetentionStrategy class:
https://github.com/jenkinsci/jenkins/blob/a5a92af4bebc73298d2061e8e95227d4e416fc74/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java#L37-L38

Override the getNode method in MesosComputer so that default retention strategy can kill our Task:
https://github.com/jenkinsci/jenkins/blob/a5a92af4bebc73298d2061e8e95227d4e416fc74/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java#L59

Add an override for doDoDelete method, MesosComputer can be deleted in two ways via RetentionStrategy or directly via the UI, 
https://github.com/mesosphere/mesos-plugin/blob/89fc6b97bd080da4683f323ff57158b4c9ac8897/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java#L66

Furthermore the original plugin needed to override the RetentionStrategy so they could kill tasks on a seperate thread because it was blocking, now with the USI based scheduler kill task is non blocking so we can allow the default retention strategy to kill the task.
