### PR TITLE
Implement a single use policy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -45,7 +45,7 @@ public class MesosApi {
   private final ActorMaterializer materializer;
   private final ExecutionContext context;
 
-  private final Integer IDLE_TERMINATION_IN_MIN = 5;
+  private final Integer IDLE_TERMINATION_IN_MIN = 1;
 
   /**
    * Establishes a connection to Mesos and provides a simple interface to start and stop {@link

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -138,6 +138,7 @@ public class MesosApi {
             jenkinsUrl,
             "label",
             IDLE_TERMINATION_IN_MIN,
+            true,
             List.of());
     PodSpec spec = mesosSlave.getPodSpec(cpu, mem, Goal.Running$.MODULE$);
     SpecUpdated update = new PodSpecUpdated(spec.id(), Option.apply(spec));

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -25,12 +25,14 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
     this.reusable = slave.getReusable();
   }
 
-
   @Override
   public void taskAccepted(Executor executor, Queue.Task task) {
     super.taskAccepted(executor, task);
     if (!reusable) {
-      //single use computer will only accept one task, after completing task it will go idle and be killed by MesosRetentionStrategy
+      // single use computer will only accept one task, after completing task it will go idle and be
+      // killed by MesosRetentionStrategy
+      logger.warn(
+          " Computer " + this + ": is no longer accepting tasks and was marked as single-use");
       setAcceptingTasks(false);
     }
     logger.info(" Computer " + this + ": task accepted");

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -25,9 +25,14 @@ public class MesosComputer extends AbstractCloudComputer<MesosSlave> {
     this.reusable = slave.getReusable();
   }
 
+
   @Override
   public void taskAccepted(Executor executor, Queue.Task task) {
     super.taskAccepted(executor, task);
+    if (!reusable) {
+      //single use computer will only accept one task, after completing task it will go idle and be killed by MesosRetentionStrategy
+      setAcceptingTasks(false);
+    }
     logger.info(" Computer " + this + ": task accepted");
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -4,7 +4,7 @@ import hudson.model.Descriptor;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
 
-/**  A strategy to terminate idle {@link MesosComputer} */
+/** A strategy to terminate idle {@link MesosComputer} */
 public class MesosRetentionStrategy extends CloudRetentionStrategy {
   /**
    * Constructs a new {@link hudson.slaves.CloudRetentionStrategy}. This is called by {@link

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -52,6 +52,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
       URL jenkinsUrl,
       String labelString,
       Integer idleTerminationInMinutes,
+      Boolean reusable,
       List<? extends NodeProperty<?>> nodeProperties)
       throws Descriptor.FormException, IOException {
     super(
@@ -66,7 +67,7 @@ public class MesosSlave extends AbstractCloudSlave implements EphemeralNode {
         nodeProperties);
     // pass around the MesosApi connection via MesosCloud
     this.cloud = cloud;
-    this.reusable = true;
+    this.reusable = reusable;
     this.podId = id;
     this.jenkinsUrl = jenkinsUrl;
   }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosSlaveLifecycleTest.java
@@ -85,4 +85,19 @@ public class MesosSlaveLifecycleTest {
     await().atMost(10, TimeUnit.SECONDS).until(agent::isKilled);
     assertThat(agent.isKilled(), is(true));
   }
+
+  @Test
+  public void testRetentionStrategy(TestUtils.JenkinsRule j) throws Exception {
+    MesosCloud cloud = new MesosCloud("mesos", mesosCluster.getMesosUrl(), j.getURL().toString());
+
+    MesosSlave agent = (MesosSlave) cloud.startAgent().get();
+    agent.waitUntilOnlineAsync().get();
+
+    assertThat(agent.isRunning(), is(true));
+    assertThat(agent.getComputer().isOnline(), is(true));
+    assertThat(agent.getComputer().isIdle(), is(true));
+
+    //after 1 minute MesosRetentionStrategy will kill the task
+    await().atMost(2, TimeUnit.MINUTES).until(agent::isKilled);
+  }
 }


### PR DESCRIPTION
A Single use Mesos Agent will start a MesosComputer which will accept one task, after completing its one task it will eventually go idle and be killed by MesosRetentionStrategy, this is similar to how the nomad plugin implements reusability: 

https://github.com/jenkinsci/nomad-plugin/blob/master/src/main/java/org/jenkinsci/plugins/nomad/NomadComputer.java#L29

The operator can manually bring the computer back online if desired within the timeout in which case it will begin accepting tasks and not be killed