### PR TITLE
 Handle backpressure from commands queue. 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -149,14 +149,14 @@ public class MesosCloud extends AbstractCloudImpl {
   public Future<Node> startAgent(String name, MesosAgentSpecTemplate spec)
       throws IOException, FormException, URISyntaxException {
     return mesosApi
-        .enqueueAgent(this, name, spec)
+        .enqueueAgent(name, spec)
         .thenCompose(
             mesosAgent -> {
               try {
                 Jenkins.get().addNode(mesosAgent);
                 logger.info("waiting for node {} to come online...", mesosAgent.getNodeName());
                 return mesosAgent
-                    .waitUntilOnlineAsync()
+                    .waitUntilOnlineAsync(mesosApi.getMaterializer())
                     .thenApply(
                         node -> {
                           logger.info("Agent {} is online", name);

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosJenkinsAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosJenkinsAgent.java
@@ -26,8 +26,7 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
 
   private static final Logger logger = LoggerFactory.getLogger(MesosJenkinsAgent.class);
 
-  // TODO: Move magic number to config.
-  private static final Duration onlineTimeout = Duration.ofMinutes(5);
+  private final Duration onlineTimeout;
 
   // Holds the current USI status for this agent.
   Optional<PodStatus> currentStatus = Optional.empty();
@@ -48,7 +47,8 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
       URL jenkinsUrl,
       Integer idleTerminationInMinutes,
       Boolean reusable,
-      List<? extends NodeProperty<?>> nodeProperties)
+      List<? extends NodeProperty<?>> nodeProperties,
+      Duration agentTimeout)
       throws Descriptor.FormException, IOException {
     super(
         name,
@@ -65,6 +65,7 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
     this.reusable = reusable;
     this.podId = name;
     this.jenkinsUrl = jenkinsUrl;
+    this.onlineTimeout = agentTimeout;
   }
 
   /**

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosJenkinsAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosJenkinsAgent.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.mesos;
 
 import akka.NotUsed;
+import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import com.mesosphere.usi.core.models.*;
@@ -33,14 +34,14 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
 
   private final Boolean reusable;
 
-  private final MesosCloud cloud;
+  private final MesosApi api;
 
   private final String podId;
 
   private final URL jenkinsUrl;
 
   public MesosJenkinsAgent(
-      MesosCloud cloud,
+      MesosApi api,
       String name,
       MesosAgentSpecTemplate spec,
       String nodeDescription,
@@ -59,8 +60,8 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
         new JNLPLauncher(),
         new MesosRetentionStrategy(idleTerminationInMinutes),
         nodeProperties);
-    // pass around the MesosApi connection via MesosCloud
-    this.cloud = cloud;
+    // pass around the MesosApi connection
+    this.api = api;
     this.reusable = reusable;
     this.podId = name;
     this.jenkinsUrl = jenkinsUrl;
@@ -72,12 +73,12 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
    *
    * @return The future agent that will come online.
    */
-  public CompletableFuture<Node> waitUntilOnlineAsync() {
+  public CompletableFuture<Node> waitUntilOnlineAsync(ActorMaterializer materializer) {
     return Source.tick(Duration.ofSeconds(0), Duration.ofSeconds(1), NotUsed.notUsed())
         .completionTimeout(onlineTimeout)
         .filter(ignored -> this.isOnline())
         .map(ignored -> this.asNode())
-        .runWith(Sink.head(), this.getCloud().getMesosApi().getMaterializer())
+        .runWith(Sink.head(), materializer)
         .toCompletableFuture();
   }
 
@@ -151,7 +152,7 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
       logger.info("killing task {}", this.podId);
       // create a terminating spec for this pod
       Jenkins.getInstanceOrNull().removeNode(this);
-      this.getCloud().getMesosApi().killAgent(this.podId);
+      this.api.killAgent(this.podId);
     } catch (Exception ex) {
       logger.warn("error when killing task {}", this.podId, ex);
     }
@@ -160,10 +161,6 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
   public Boolean getReusable() {
     // TODO: implement reusable slaves
     return reusable;
-  }
-
-  public MesosCloud getCloud() {
-    return cloud;
   }
 
   /** get the podId tied to this task. */

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/Settings.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/Settings.java
@@ -41,6 +41,7 @@ public class Settings {
 
   /**
    * Factory method to construct {@link Settings} from a Lightbend {@link Config}.
+   *
    * @param conf The Lightbend config object.
    * @return a new settings instances.
    */

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/Settings.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/Settings.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.mesos.api;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.time.Duration;
+
+/**
+ * Operation settings for the Jenkins plugin. These should not be set by Jenkins admins and users
+ * but rather by Jenkins operators.
+ */
+public class Settings {
+
+  private final Duration agentTimeout;
+  private final int commandQueueBufferSize;
+
+  public Settings(Duration agentTimeout, int commandQueueBufferSize) {
+    this.agentTimeout = agentTimeout;
+    this.commandQueueBufferSize = commandQueueBufferSize;
+  }
+
+  public Settings withCommandQueueBufferSize(int commandQueueBufferSize) {
+    return new Settings(this.agentTimeout, commandQueueBufferSize);
+  }
+
+  public Duration getAgentTimeout() {
+    return this.agentTimeout;
+  }
+
+  public int getCommandQueueBufferSize() {
+    return this.commandQueueBufferSize;
+  }
+
+  public static Settings fromConfig(Config conf) {
+    return new Settings(
+        conf.getDuration("agent-timeout"), conf.getInt("command-queue-buffer-size"));
+  }
+
+  public static Settings load(ClassLoader loader) {
+    Config conf = ConfigFactory.load(loader).getConfig("usi.jenkins");
+    return fromConfig(conf);
+  }
+
+  public static Settings load() {
+    Config conf = ConfigFactory.load().getConfig("usi.jenkins");
+    return fromConfig(conf);
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/Settings.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/Settings.java
@@ -13,33 +13,54 @@ public class Settings {
   private final Duration agentTimeout;
   private final int commandQueueBufferSize;
 
-  public Settings(Duration agentTimeout, int commandQueueBufferSize) {
+  /** Internal constructor */
+  private Settings(Duration agentTimeout, int commandQueueBufferSize) {
     this.agentTimeout = agentTimeout;
     this.commandQueueBufferSize = commandQueueBufferSize;
   }
 
+  /** @return copy of these settings with overridden command queue buffer size. */
   public Settings withCommandQueueBufferSize(int commandQueueBufferSize) {
     return new Settings(this.agentTimeout, commandQueueBufferSize);
   }
 
+  /** @return copy of these settings with overridden agent timeout. */
+  public Settings withAgentTimeout(Duration agentTimeout) {
+    return new Settings(agentTimeout, this.commandQueueBufferSize);
+  }
+
+  /** @return agent timeout setting. */
   public Duration getAgentTimeout() {
     return this.agentTimeout;
   }
 
+  /** @return command queue buffer size setting. */
   public int getCommandQueueBufferSize() {
     return this.commandQueueBufferSize;
   }
 
+  /**
+   * Factory method to construct {@link Settings} from a Lightbend {@link Config}.
+   * @param conf The Lightbend config object.
+   * @return a new settings instances.
+   */
   public static Settings fromConfig(Config conf) {
     return new Settings(
         conf.getDuration("agent-timeout"), conf.getInt("command-queue-buffer-size"));
   }
 
+  /**
+   * Factory method to construct {@link Settings} with Lightbend {@link ConfigFactory}.
+   *
+   * @param loader The class loader used to find application.conf and reference.conf.
+   * @return a new settings instance loaded from "usi.jenkins" in resources.
+   */
   public static Settings load(ClassLoader loader) {
     Config conf = ConfigFactory.load(loader).getConfig("usi.jenkins");
     return fromConfig(conf);
   }
 
+  /** @return a new settings instance loaded from "usi.jenkins" in resources. */
   public static Settings load() {
     Config conf = ConfigFactory.load().getConfig("usi.jenkins");
     return fromConfig(conf);

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -27,3 +27,11 @@ akka {
     idle-timeout = infinite
   }
 }
+
+usi {
+  # Operational Jenkins configuration.
+  jenkins {
+    agent-timeout: "5 minutes"
+    command-queue-buffer-size: 256
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -1,0 +1,33 @@
+package org.jenkinsci.plugins.mesos.fixture;
+
+import hudson.model.Node.Mode;
+import hudson.model.labels.LabelAtom;
+import org.jenkinsci.plugins.mesos.MesosAgentSpecTemplate;
+
+/**
+ * A Mother object for {@link org.jenkinsci.plugins.mesos.MesosAgentSpecTemplate}.
+ *
+ * @see <a href="https://martinfowler.com/bliki/ObjectMother.html">ObjectMother</a>
+ */
+public class AgentSpecMother {
+
+  public static MesosAgentSpecTemplate simple =
+    new MesosAgentSpecTemplate(
+            "label",
+            Mode.EXCLUSIVE,
+            "0.1",
+            "32",
+            "1",
+            true,
+            "1",
+            "1",
+            "0",
+            "0",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "");
+}

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.mesos.fixture;
 
 import hudson.model.Node.Mode;
-import hudson.model.labels.LabelAtom;
 import org.jenkinsci.plugins.mesos.MesosAgentSpecTemplate;
 
 /**
@@ -12,22 +11,22 @@ import org.jenkinsci.plugins.mesos.MesosAgentSpecTemplate;
 public class AgentSpecMother {
 
   public static MesosAgentSpecTemplate simple =
-    new MesosAgentSpecTemplate(
-            "label",
-            Mode.EXCLUSIVE,
-            "0.1",
-            "32",
-            "1",
-            true,
-            "1",
-            "1",
-            "0",
-            "0",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "");
+      new MesosAgentSpecTemplate(
+          "label",
+          Mode.EXCLUSIVE,
+          "0.1",
+          "32",
+          "1",
+          true,
+          "1",
+          "1",
+          "0",
+          "0",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "");
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
@@ -4,8 +4,13 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.SourceQueueWithComplete;
+import com.mesosphere.usi.core.models.SchedulerCommand;
+import com.mesosphere.usi.core.models.StateEventOrSnapshot;
 import com.mesosphere.utils.mesos.MesosClusterExtension;
 import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
 import hudson.model.Descriptor.FormException;
@@ -14,6 +19,7 @@ import hudson.model.labels.LabelAtom;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
@@ -22,6 +28,7 @@ import org.jenkinsci.plugins.mesos.MesosApi;
 import org.jenkinsci.plugins.mesos.MesosJenkinsAgent;
 import org.jenkinsci.plugins.mesos.TestUtils.JenkinsParameterResolver;
 import org.jenkinsci.plugins.mesos.TestUtils.JenkinsRule;
+import org.jenkinsci.plugins.mesos.fixture.AgentSpecMother;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -53,29 +60,9 @@ class MesosApiTest {
         new MesosApi(mesosUrl, jenkinsUrl, System.getProperty("user.name"), "MesosTest", "*");
 
     final String name = "jenkins-start-agent";
-    final String idleMin = "1";
-    LabelAtom label = new LabelAtom("label");
-    final MesosAgentSpecTemplate spec =
-        new MesosAgentSpecTemplate(
-            label.toString(),
-            Mode.EXCLUSIVE,
-            "0.1",
-            "32",
-            idleMin,
-            true,
-            "1",
-            "1",
-            "0",
-            "0",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "");
+    final MesosAgentSpecTemplate spec = AgentSpecMother.simple;
 
-    MesosJenkinsAgent agent = api.enqueueAgent(null, name, spec).toCompletableFuture().get();
+    MesosJenkinsAgent agent = api.enqueueAgent(name, spec).toCompletableFuture().get();
 
     Awaitility.await().atMost(5, TimeUnit.MINUTES).until(agent::isRunning);
   }
@@ -88,29 +75,9 @@ class MesosApiTest {
     MesosApi api =
         new MesosApi(mesosUrl, jenkinsUrl, System.getProperty("user.name"), "MesosTest", "*");
     final String name = "jenkins-stop-agent";
-    final String idleMin = "1";
-    LabelAtom label = new LabelAtom("label");
-    final MesosAgentSpecTemplate spec =
-        new MesosAgentSpecTemplate(
-            label.toString(),
-            Mode.EXCLUSIVE,
-            "0.1",
-            "32",
-            idleMin,
-            true,
-            "1",
-            "1",
-            "0",
-            "0",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "");
+    final MesosAgentSpecTemplate spec = AgentSpecMother.simple;
 
-    MesosJenkinsAgent agent = api.enqueueAgent(null, name, spec).toCompletableFuture().get();
+    MesosJenkinsAgent agent = api.enqueueAgent(name, spec).toCompletableFuture().get();
     // Poll state until we get something.
     await().atMost(5, TimeUnit.MINUTES).until(agent::isRunning);
     assertThat(agent.isRunning(), equalTo(true));
@@ -118,5 +85,31 @@ class MesosApiTest {
     api.killAgent(agent.getPodId());
     await().atMost(5, TimeUnit.MINUTES).until(agent::isKilled);
     assertThat(agent.isKilled(), equalTo(true));
+  }
+
+  @Test
+  public void testLaunchOverflow() throws Exception {
+    // Given a scheduler flow that never processes commands.
+    final CompletableFuture<StateEventOrSnapshot> never = new CompletableFuture<>();
+    final Flow<SchedulerCommand, StateEventOrSnapshot, NotUsed> schedulerFlow =
+        Flow.of(SchedulerCommand.class).mapAsync(1, command -> never);
+
+    MesosApi api =
+        new MesosApi(
+            new URL("http://jenkins.com"),
+            System.getProperty("user.name"),
+            "MesosTest",
+            "uniqueId",
+            "*",
+            schedulerFlow,
+            system,
+            materializer);
+
+    // When we enqueue an agent
+    api.enqueueAgent("agent1", AgentSpecMother.simple);
+    api.enqueueAgent("agent2", AgentSpecMother.simple).toCompletableFuture().get(1, TimeUnit.SECONDS);
+
+
+    // Then backpressure hits us.
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
@@ -3,19 +3,18 @@ package org.jenkinsci.plugins.mesos.integration;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
-import akka.stream.javadsl.SourceQueueWithComplete;
 import com.mesosphere.usi.core.models.SchedulerCommand;
 import com.mesosphere.usi.core.models.StateEventOrSnapshot;
 import com.mesosphere.utils.mesos.MesosClusterExtension;
 import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
 import hudson.model.Descriptor.FormException;
-import hudson.model.Node.Mode;
-import hudson.model.labels.LabelAtom;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -28,6 +27,7 @@ import org.jenkinsci.plugins.mesos.MesosApi;
 import org.jenkinsci.plugins.mesos.MesosJenkinsAgent;
 import org.jenkinsci.plugins.mesos.TestUtils.JenkinsParameterResolver;
 import org.jenkinsci.plugins.mesos.TestUtils.JenkinsRule;
+import org.jenkinsci.plugins.mesos.api.Settings;
 import org.jenkinsci.plugins.mesos.fixture.AgentSpecMother;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -88,11 +88,12 @@ class MesosApiTest {
   }
 
   @Test
-  public void testLaunchOverflow() throws Exception {
+  public void testLaunchOverflow(JenkinsRule j) throws Exception {
     // Given a scheduler flow that never processes commands.
-    final CompletableFuture<StateEventOrSnapshot> never = new CompletableFuture<>();
+    Settings settings = Settings.load().withCommandQueueBufferSize(1);
+    final CompletableFuture<StateEventOrSnapshot> ignore = new CompletableFuture<>();
     final Flow<SchedulerCommand, StateEventOrSnapshot, NotUsed> schedulerFlow =
-        Flow.of(SchedulerCommand.class).mapAsync(1, command -> never);
+        Flow.of(SchedulerCommand.class).mapAsync(1, command -> ignore);
 
     MesosApi api =
         new MesosApi(
@@ -102,14 +103,24 @@ class MesosApiTest {
             "uniqueId",
             "*",
             schedulerFlow,
+            settings,
             system,
             materializer);
 
-    // When we enqueue an agent
+    // And one agent is processed and one is queued.
     api.enqueueAgent("agent1", AgentSpecMother.simple);
-    api.enqueueAgent("agent2", AgentSpecMother.simple).toCompletableFuture().get(1, TimeUnit.SECONDS);
+    api.enqueueAgent("agent2", AgentSpecMother.simple);
 
+    // When we enqueue a third agent
+    CompletableFuture<MesosJenkinsAgent> result =
+        api.enqueueAgent("agent3", AgentSpecMother.simple).toCompletableFuture();
 
     // Then backpressure hits us.
+    try {
+      result.get();
+    } catch (ExecutionException ex) {
+      assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
+      assertThat(ex.getCause().getMessage(), is("Launch command for agent3 was dropped."));
+    }
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
@@ -9,8 +9,6 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import com.mesosphere.utils.mesos.MesosClusterExtension;
 import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
-import hudson.model.Node.Mode;
-import hudson.model.labels.LabelAtom;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
@@ -18,6 +18,7 @@ import org.jenkinsci.plugins.mesos.MesosAgentSpecTemplate;
 import org.jenkinsci.plugins.mesos.MesosCloud;
 import org.jenkinsci.plugins.mesos.MesosJenkinsAgent;
 import org.jenkinsci.plugins.mesos.TestUtils;
+import org.jenkinsci.plugins.mesos.fixture.AgentSpecMother;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -49,29 +50,9 @@ public class MesosJenkinsAgentLifecycleTest {
             new ArrayList<>());
 
     final String name = "jenkins-lifecycle";
-    final String idleMin = "1";
-    LabelAtom label = new LabelAtom("label");
-    final MesosAgentSpecTemplate spec =
-        new MesosAgentSpecTemplate(
-            label.toString(),
-            Mode.EXCLUSIVE,
-            "0.1",
-            "32",
-            idleMin,
-            true,
-            "1",
-            "1",
-            "0",
-            "0",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "");
+    final MesosAgentSpecTemplate spec = AgentSpecMother.simple;
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
-    agent.waitUntilOnlineAsync().get();
+    agent.waitUntilOnlineAsync(materializer).get();
 
     // verify slave is running when the future completes;
     assertThat(agent.isRunning(), is(true));
@@ -97,30 +78,10 @@ public class MesosJenkinsAgentLifecycleTest {
             new ArrayList<>());
 
     final String name = "jenkins-node-terminate";
-    final String idleMin = "1";
-    LabelAtom label = new LabelAtom("label");
-    final MesosAgentSpecTemplate spec =
-        new MesosAgentSpecTemplate(
-            label.toString(),
-            Mode.EXCLUSIVE,
-            "0.1",
-            "32",
-            idleMin,
-            true,
-            "1",
-            "1",
-            "0",
-            "0",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "");
+    final MesosAgentSpecTemplate spec = AgentSpecMother.simple;
 
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
-    agent.waitUntilOnlineAsync().get();
+    agent.waitUntilOnlineAsync(materializer).get();
 
     assertThat(agent.isRunning(), is(true));
     assertThat(agent.getComputer().isOnline(), is(true));
@@ -143,30 +104,10 @@ public class MesosJenkinsAgentLifecycleTest {
             new ArrayList<>());
 
     final String name = "jenkins-node-delete";
-    final String idleMin = "1";
-    LabelAtom label = new LabelAtom("label");
-    final MesosAgentSpecTemplate spec =
-        new MesosAgentSpecTemplate(
-            label.toString(),
-            Mode.EXCLUSIVE,
-            "0.1",
-            "32",
-            idleMin,
-            true,
-            "1",
-            "1",
-            "0",
-            "0",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "");
+    final MesosAgentSpecTemplate spec = AgentSpecMother.simple;
 
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
-    agent.waitUntilOnlineAsync().get();
+    agent.waitUntilOnlineAsync(materializer).get();
 
     assertThat(agent.isRunning(), is(true));
     assertThat(agent.getComputer().isOnline(), is(true));
@@ -189,30 +130,10 @@ public class MesosJenkinsAgentLifecycleTest {
             new ArrayList<>());
 
     final String name = "jenkins-node-delete";
-    final String idleMin = "1";
-    LabelAtom label = new LabelAtom("label");
-    final MesosAgentSpecTemplate spec =
-        new MesosAgentSpecTemplate(
-            label.toString(),
-            Mode.EXCLUSIVE,
-            "0.1",
-            "32",
-            idleMin,
-            true,
-            "1",
-            "1",
-            "0",
-            "0",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            null);
+    final MesosAgentSpecTemplate spec = AgentSpecMother.simple;
 
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
-    agent.waitUntilOnlineAsync().get();
+    agent.waitUntilOnlineAsync(materializer).get();
 
     assertThat(agent.isRunning(), is(true));
     assertThat(agent.getComputer().isOnline(), is(true));


### PR DESCRIPTION
Summary:
When the USI commands queue is filled we should not provision more
agents. This change lets the agent provisioning failed since Jenkins
won't give us an option to backpressure.

This change also introduces also a `MotherObject` for `AgentSpecTemplates`.
This ease sharing fixtures. See the linked article in the docs.

Furthermore we introduce operational settings for the plugin that are the
same across all `MesosCloud` instances.

JIRA issues: DCOS_OSS-5054