### PR TITLE
Do not spam our channels with notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,13 +2,13 @@
 
 @Library('sec_ci_libs@v2-latest') _
 
-def master_branches = ["master", "usi-jenkins", ] as String[]
+def master_branches = ["master", ] as String[]
 
 ansiColor('xterm') {
   // using shakedown node because it's a lightweight alpine docker image instead of full VM
   node('shakedown') {
     stage("Verify author") {
-      user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#orchestration-dailies')
+      user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dev-null')
     }
   }
   //node('mesos-med') {


### PR DESCRIPTION
Out of last 20 messages in our team channel, 17 of those were build notifications from security plugin. When working properly, these messages should not be sent for mesosphere employees. I don't feel like debugging jenkins plugin right now so my proposal is not send these messages to non-existent slack channel which basically means ignore them.

This does not mean we won't be able to run community builds anymore! These will still appear in PR queue and we will be able to approve the run in jenkins.