### PR TITLE
 Build Docker image of Jenkins with plugin.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-# BUILD
+# Stage: Build
 FROM gradle:5.4.1-jdk8 AS build
 ADD . /home/gradle/project
 WORKDIR /home/gradle/project
-
 RUN gradle jpi
 
 
-# IMAGE
+# Stage: Prod
 FROM jenkins/jenkins:2.164
+
+# Default policy according to https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy
+ENV JENKINS_CSP_OPTS="sandbox; default-src 'none'; img-src 'self'; style-src 'self';"
 
 # Install plugin
 ENV JENKINS_REF=/usr/share/jenkins/ref/
 COPY --from=build /home/gradle/project/build/libs/mesos.hpi "${JENKINS_REF}/plugins/mesos.hpi"
 
 # Disable first-run wizard
-RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
+RUN echo 2.0 > "${JENKINS_REF}/jenkins.install.UpgradeWizard.state"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# BUILD
+FROM gradle:5.4.1-jdk8 AS build
+ADD . /home/gradle/project
+WORKDIR /home/gradle/project
+
+RUN gradle jpi
+
+
+# IMAGE
+FROM jenkins/jenkins:2.164
+
+# Install plugin
+ENV JENKINS_REF=/usr/share/jenkins/ref/
+COPY --from=build /home/gradle/project/build/libs/mesos.hpi "${JENKINS_REF}/plugins/mesos.hpi"
+
+# Disable first-run wizard
+RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -154,8 +154,7 @@ public class MesosApi {
    * @return A running source queue.
    */
   private SourceQueueWithComplete<SchedulerCommand> runScheduler(
-      Flow<SchedulerCommand, StateEvent, NotUsed> schedulerFlow,
-      ActorMaterializer materializer) {
+      Flow<SchedulerCommand, StateEvent, NotUsed> schedulerFlow, ActorMaterializer materializer) {
     return Source.<SchedulerCommand>queue(
             operationalSettings.getCommandQueueBufferSize(), OverflowStrategy.dropNew())
         .via(schedulerFlow)

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -120,7 +120,7 @@ public class MesosApi {
       String frameworkName,
       String frameworkId,
       String role,
-      Flow<SchedulerCommand, StateEventOrSnapshot, NotUsed> schedulerFlow,
+      Flow<SchedulerCommand, StateEvent, NotUsed> schedulerFlow,
       Settings operationalSettings,
       ActorSystem system,
       ActorMaterializer materializer) {
@@ -150,7 +150,7 @@ public class MesosApi {
    * @return A running source queue.
    */
   private SourceQueueWithComplete<SchedulerCommand> runScheduler(
-      Flow<SchedulerCommand, StateEventOrSnapshot, NotUsed> schedulerFlow,
+      Flow<SchedulerCommand, StateEvent, NotUsed> schedulerFlow,
       ActorMaterializer materializer) {
     return Source.<SchedulerCommand>queue(
             operationalSettings.getCommandQueueBufferSize(), OverflowStrategy.dropNew())
@@ -240,7 +240,7 @@ public class MesosApi {
             .build();
 
     return MesosClient$.MODULE$
-        .apply(clientSettings, frameworkInfo, system, materializer)
+        .apply(clientSettings, frameworkInfo, scala.Option.empty(), system, materializer)
         .runWith(Sink.head(), materializer)
         .toCompletableFuture();
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
@@ -91,7 +91,9 @@ public class LaunchCommandBuilder {
             convertListToSeq(Arrays.asList(this.cpus, this.memory, this.disk)),
             this.buildCommand(),
             this.role,
-            convertListToSeq(Arrays.asList(buildFetchUri())));
+            convertListToSeq(Arrays.asList(buildFetchUri())),
+            scala.Option.empty()
+        );
     return new LaunchPod(this.id, runTemplate);
   }
 

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
@@ -11,7 +11,7 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 import com.mesosphere.usi.core.models.SchedulerCommand;
-import com.mesosphere.usi.core.models.StateEventOrSnapshot;
+import com.mesosphere.usi.core.models.StateEvent;
 import com.mesosphere.utils.mesos.MesosClusterExtension;
 import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
 import hudson.model.Descriptor.FormException;
@@ -91,8 +91,8 @@ class MesosApiTest {
   public void testLaunchOverflow(JenkinsRule j) throws Exception {
     // Given a scheduler flow that never processes commands.
     Settings settings = Settings.load().withCommandQueueBufferSize(1);
-    final CompletableFuture<StateEventOrSnapshot> ignore = new CompletableFuture<>();
-    final Flow<SchedulerCommand, StateEventOrSnapshot, NotUsed> schedulerFlow =
+    final CompletableFuture<StateEvent> ignore = new CompletableFuture<>();
+    final Flow<SchedulerCommand, StateEvent, NotUsed> schedulerFlow =
         Flow.of(SchedulerCommand.class).mapAsync(1, command -> ignore);
 
     MesosApi api =
@@ -128,8 +128,8 @@ class MesosApiTest {
   void testKillOverflow(JenkinsRule j) throws Exception {
     // Given a scheduler flow that never processes commands.
     Settings settings = Settings.load().withCommandQueueBufferSize(1);
-    final CompletableFuture<StateEventOrSnapshot> ignore = new CompletableFuture<>();
-    final Flow<SchedulerCommand, StateEventOrSnapshot, NotUsed> schedulerFlow =
+    final CompletableFuture<StateEvent> ignore = new CompletableFuture<>();
+    final Flow<SchedulerCommand, StateEvent, NotUsed> schedulerFlow =
         Flow.of(SchedulerCommand.class).mapAsync(1, command -> ignore);
 
     MesosApi api =


### PR DESCRIPTION
Summary:
This change imports the `Dockerfile` from [mesosphere/dcos-jenkins-service](https://github.com/mesosphere/dcos-jenkins-service) and slims it down quite a bit. It relates to the work by @DominikDary. See #60.

The Docker build also builds the plugin in a different stage. Docker hub has been configured to build
master and provide `mesosphere/jenkins:latest`. The actual DC/OS Cosmos package should build
upon this image.

You can try the image the following way
1. Build `docker build -t mesosphere/jenkins .`
2. Run ZooKeeper, Mesos master and agent.
3. Start Jenkins with `docker run -p 8080:8080 -p 50000:50000 mesosphere/jenkins:latest`.
4. Add a Mesos Cloud with
  4.1 Mesos Master: `http://host.docker.internal:5050`. See [Networking](https://docs.docker.com/docker-for-mac/networking/).