### PR TITLE
Detect Mesos master URL.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.17-1cb2c1f-SNAPSHOT'
+    usiVersion= '0.1.18'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.14-4d9dcbd-SNAPSHOT'
+    usiVersion= '0.1.14-858c3d0-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.14'
+    usiVersion= '0.1.14-4d9dcbd-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.14-858c3d0-SNAPSHOT'
+    usiVersion= '0.1.15'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }
@@ -32,6 +32,7 @@ dependencies {
     api group: 'com.mesosphere.usi', name: 'core', version: usiVersion
     api group: 'com.mesosphere.usi', name: 'core-models', version: usiVersion
     api group: 'com.mesosphere.usi', name: 'mesos-client', version: usiVersion
+    api group: 'com.mesosphere.usi', name: 'mesos-master-detector', version: usiVersion
     api group: 'com.mesosphere.usi', name: 'metrics-dropwizard', version: usiVersion
     api group: 'com.mesosphere.usi', name: 'persistence', version: usiVersion
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.17-3b0db2d-SNAPSHOT'
+    usiVersion= '0.1.17-1cb2c1f-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.17-a9abfd2-SNAPSHOT'
+    usiVersion= '0.1.17-2cc2fea-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.17-66eae22-SNAPSHOT'
+    usiVersion= '0.1.17-3b0db2d-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.17-2cc2fea-SNAPSHOT'
+    usiVersion= '0.1.17-66eae22-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.15'
+    usiVersion= '0.1.17-a9abfd2-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -75,7 +75,11 @@ public class MesosApi {
    * Establishes a connection to Mesos and provides a simple interface to start and stop {@link
    * MesosJenkinsAgent} instances.
    *
-   * @param masterUrl The Mesos master address to connect to.
+   * @param masterUrl The Mesos master address to connect to. Should be one of
+   *                  host:port
+   *                  http://host:port
+   *                  zk://host1:port1,host2:port2,.../path
+   *                  zk://username:password@host1:port1,host2:port2,.../path
    * @param jenkinsUrl The Jenkins address to fetch the agent jar from.
    * @param agentUser The username used for executing Mesos tasks.
    * @param frameworkName The name of the framework the Mesos client should register as.
@@ -87,7 +91,7 @@ public class MesosApi {
    * @throws ExecutionException
    */
   public MesosApi(
-      URL masterUrl,
+      String master,
       URL jenkinsUrl,
       String agentUser,
       String frameworkName,
@@ -116,6 +120,8 @@ public class MesosApi {
     } else {
       conf = ConfigFactory.load(classLoader);
     }
+
+    URL masterUrl = MasterDetector.apply(master).getMaster();
 
     MesosClientSettings clientSettings =
         MesosClientSettings.load(classLoader).withMasters(Collections.singletonList(masterUrl));

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -49,7 +49,7 @@ public class MesosCloud extends AbstractCloudImpl {
 
   private static final Logger logger = LoggerFactory.getLogger(MesosCloud.class);
 
-  private URL mesosMasterUrl;
+  private String master;
 
   @Nonnull private transient MesosApi mesosApi;
 
@@ -87,7 +87,6 @@ public class MesosCloud extends AbstractCloudImpl {
 
   // Legacy 1.x fields required for backwards compatibility
   private transient String nativeLibraryPath;
-  private transient String master;
   private transient String description;
   private transient String slavesUser;
   private transient String credentialsId;
@@ -109,14 +108,10 @@ public class MesosCloud extends AbstractCloudImpl {
     super("MesosCloud", null);
 
     try {
-      this.mesosMasterUrl = new URL(mesosMasterUrl);
+      this.master = mesosMasterUrl;
       this.jenkinsURL = new URL(jenkinsURL);
     } catch (MalformedURLException e) {
-      throw new RuntimeException(
-          String.format(
-              "Mesos Cloud URL validation failed for Mesos %s, Jenkins %s",
-              mesosMasterUrl, jenkinsURL),
-          e);
+      throw new RuntimeException(String.format("Mesos Cloud URL validation failed for Jenkins %s", jenkinsURL), e);
     }
 
     if (selfIsMesosTask()) {
@@ -136,7 +131,7 @@ public class MesosCloud extends AbstractCloudImpl {
 
     this.mesosApi =
         new MesosApi(
-            this.mesosMasterUrl,
+            this.master,
             this.jenkinsURL,
             this.agentUser,
             this.frameworkName,
@@ -158,11 +153,6 @@ public class MesosCloud extends AbstractCloudImpl {
 
     if (this.frameworkId == null) {
       this.frameworkId = "???"; // Is this this.cloudID?
-    }
-
-    if (this.mesosMasterUrl == null) {
-      // TODO: infer from zk this.master
-      this.mesosMasterUrl = new URL(this.master);
     }
 
     if (this.mesosAgentSpecTemplates == null && this.slaveInfos != null) {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.mesos;
 import static java.lang.Math.toIntExact;
 
 import com.codahale.metrics.Timer;
+import com.mesosphere.mesos.client.MasterDetector$;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
@@ -382,11 +383,10 @@ public class MesosCloud extends AbstractCloudImpl {
      * @return Whether the URL is valid or not.
      */
     public FormValidation doCheckMesosMasterUrl(@QueryParameter String mesosMasterUrl) {
-      // This will change with https://jira.mesosphere.com/browse/DCOS-53671.
-      if (isValidUrl(mesosMasterUrl)) {
+      if (MasterDetector$.MODULE$.apply(mesosMasterUrl).isValid()) {
         return FormValidation.ok();
       } else {
-        return FormValidation.error(mesosMasterUrl + " is not a valid URL.");
+        return FormValidation.error(mesosMasterUrl + " is not a valid URL or Zookeeper connection string.");
       }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -111,7 +111,8 @@ public class MesosCloud extends AbstractCloudImpl {
       this.master = mesosMasterUrl;
       this.jenkinsURL = new URL(jenkinsURL);
     } catch (MalformedURLException e) {
-      throw new RuntimeException(String.format("Mesos Cloud URL validation failed for Jenkins %s", jenkinsURL), e);
+      throw new RuntimeException(
+          String.format("Mesos Cloud URL validation failed for Jenkins %s", jenkinsURL), e);
     }
 
     if (selfIsMesosTask()) {
@@ -174,7 +175,7 @@ public class MesosCloud extends AbstractCloudImpl {
     try {
       this.mesosApi =
           new MesosApi(
-              this.mesosMasterUrl,
+              this.master,
               this.jenkinsURL,
               this.agentUser,
               this.frameworkName,
@@ -516,7 +517,7 @@ public class MesosCloud extends AbstractCloudImpl {
   }
 
   public String getMesosMasterUrl() {
-    return this.mesosMasterUrl.toString();
+    return this.master;
   }
 
   public String getFrameworkName() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -386,7 +386,8 @@ public class MesosCloud extends AbstractCloudImpl {
       if (MasterDetector$.MODULE$.apply(mesosMasterUrl).isValid()) {
         return FormValidation.ok();
       } else {
-        return FormValidation.error(mesosMasterUrl + " is not a valid URL or Zookeeper connection string.");
+        return FormValidation.error(
+            mesosMasterUrl + " is not a valid URL or Zookeeper connection string.");
       }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -384,7 +384,9 @@ public class MesosCloud extends AbstractCloudImpl {
      * @return Whether the URL is valid or not.
      */
     public FormValidation doCheckMesosMasterUrl(@QueryParameter String mesosMasterUrl) {
-      if (MasterDetector$.MODULE$.apply(mesosMasterUrl, null).isValid()) {
+      if (MasterDetector$.MODULE$
+          .apply(mesosMasterUrl, org.jenkinsci.plugins.mesos.Metrics.getInstance("no_name"))
+          .isValid()) {
         return FormValidation.ok();
       } else {
         return FormValidation.error(
@@ -479,7 +481,7 @@ public class MesosCloud extends AbstractCloudImpl {
       try {
         URL masterUrl =
             MasterDetector$.MODULE$
-                .apply(mesosMasterUrl, null)
+                .apply(mesosMasterUrl, org.jenkinsci.plugins.mesos.Metrics.getInstance("no_name"))
                 .getMaster(Implicits$.MODULE$.global())
                 .toCompletableFuture()
                 .get();

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.mesos;
 import static java.lang.Math.toIntExact;
 
 import com.codahale.metrics.Timer;
-import com.mesosphere.mesos.client.MasterDetector$;
+import com.mesosphere.mesos.MasterDetector$;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
@@ -384,7 +384,7 @@ public class MesosCloud extends AbstractCloudImpl {
      * @return Whether the URL is valid or not.
      */
     public FormValidation doCheckMesosMasterUrl(@QueryParameter String mesosMasterUrl) {
-      if (MasterDetector$.MODULE$.apply(mesosMasterUrl).isValid()) {
+      if (MasterDetector$.MODULE$.apply(mesosMasterUrl, null).isValid()) {
         return FormValidation.ok();
       } else {
         return FormValidation.error(
@@ -479,7 +479,7 @@ public class MesosCloud extends AbstractCloudImpl {
       try {
         URL masterUrl =
             MasterDetector$.MODULE$
-                .apply(mesosMasterUrl)
+                .apply(mesosMasterUrl, null)
                 .getMaster(Implicits$.MODULE$.global())
                 .toCompletableFuture()
                 .get();

--- a/src/main/java/org/jenkinsci/plugins/mesos/Metrics.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Metrics.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.plugins.mesos;
+
+import com.mesosphere.usi.metrics.dropwizard.conf.HistorgramSettings;
+import com.mesosphere.usi.metrics.dropwizard.conf.MetricsSettings;
+import java.util.HashMap;
+import javax.annotation.Nonnull;
+import scala.Option;
+
+public class Metrics {
+
+  @Nonnull
+  private static HashMap<String, com.mesosphere.usi.metrics.Metrics> metrics = new HashMap<>();
+
+  /**
+   * The USI metrics is a singleton per framework name.
+   *
+   * <p>A singleton is required because we use in in validation code in {@link MesosCloud} and in
+   * {@link MesosApi} instances.
+   *
+   * @param frameworkName The name of the framework that is used as a prefix.
+   * @return The Metrics implementation for the framework.
+   */
+  public static synchronized com.mesosphere.usi.metrics.Metrics getInstance(String frameworkName) {
+    final String prefix = sanitize(frameworkName);
+    if (!metrics.containsKey(prefix)) {
+      // Construct metrics
+      MetricsSettings metricsSettings =
+          new MetricsSettings(
+              sanitize(frameworkName),
+              HistorgramSettings.apply(
+                  HistorgramSettings.apply$default$1(),
+                  HistorgramSettings.apply$default$2(),
+                  HistorgramSettings.apply$default$3(),
+                  HistorgramSettings.apply$default$4(),
+                  HistorgramSettings.apply$default$5()),
+              Option.empty(),
+              Option.empty());
+      metrics.put(
+          prefix,
+          new com.mesosphere.usi.metrics.dropwizard.DropwizardMetrics(
+              metricsSettings, jenkins.metrics.api.Metrics.metricRegistry()));
+    }
+
+    return metrics.get(prefix);
+  }
+
+  /** @return a santized prefix for Dropwizard metrics. */
+  public static String sanitize(String prefix) {
+    return prefix.replaceAll("[^a-zA-Z0-9\\-\\.]", "-");
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudDescriptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudDescriptorTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 
 import hudson.util.FormValidation.Kind;
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import org.jenkinsci.plugins.mesos.MesosCloud.DescriptorImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +17,9 @@ public class MesosCloudDescriptorTest {
   void validateMesosMasterUrl(TestUtils.JenkinsRule j) {
     MesosCloud.DescriptorImpl descriptor = new DescriptorImpl();
     assertThat(descriptor.doCheckMesosMasterUrl("http/other").kind, is(Kind.ERROR));
-    assertThat(descriptor.doCheckMesosMasterUrl("zk://localhost:5050").kind, is(Kind.ERROR));
+    assertThat(
+        descriptor.doCheckMesosMasterUrl("zk://user@pass@localhost:5050").kind, is(Kind.ERROR));
+    assertThat(descriptor.doCheckMesosMasterUrl("zk://localhost:5050").kind, is(Kind.OK));
     assertThat(descriptor.doCheckMesosMasterUrl("http://localhost:5050").kind, is(Kind.OK));
     assertThat(descriptor.doCheckMesosMasterUrl("https://localhost:5050").kind, is(Kind.OK));
   }
@@ -65,7 +68,8 @@ public class MesosCloudDescriptorTest {
   }
 
   @Test
-  void connectionTest(TestUtils.JenkinsRule j) throws IOException {
+  void connectionTest(TestUtils.JenkinsRule j)
+      throws ExecutionException, InterruptedException, IOException {
     MesosCloud.DescriptorImpl descriptor = new DescriptorImpl();
     assertThat(descriptor.doTestConnection("invalid url").kind, is(Kind.ERROR));
     assertThat(descriptor.doTestConnection("http://unknownhost.foo").kind, is(Kind.ERROR));

--- a/src/test/java/org/jenkinsci/plugins/mesos/MetricsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MetricsTest.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.mesos;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+public class MetricsTest {
+
+  @Test
+  void metricsPrefixSanitization() {
+    final String prefix = "I'm an invalid pref$x!.1";
+    assertThat(Metrics.sanitize(prefix), is("I-m-an-invalid-pref-x-.1"));
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
@@ -10,6 +10,7 @@ import com.mesosphere.utils.mesos.MesosClusterExtension;
 import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.jenkinsci.plugins.mesos.MesosAgentSpecTemplate;
 import org.jenkinsci.plugins.mesos.MesosCloud;
 import org.jenkinsci.plugins.mesos.MesosJenkinsAgent;
@@ -21,6 +22,8 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import scala.Option;
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
 
 @ExtendWith(TestUtils.JenkinsParameterResolver.class)
 public class DockerAgentTest {
@@ -37,7 +40,9 @@ public class DockerAgentTest {
           Option.apply("filesystem/linux,docker/runtime"),
           Option.apply("docker"),
           Option.empty(),
-          Option.empty());
+          Option.empty(),
+          Option.apply(new FiniteDuration(7, TimeUnit.MINUTES)),
+          Option.apply(new FiniteDuration(5, TimeUnit.MINUTES)));
 
   @RegisterExtension
   static MesosClusterExtension mesosCluster =

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
@@ -40,8 +40,8 @@ public class DockerAgentTest {
           Option.apply("docker"),
           Option.empty(),
           Option.empty(),
-          Option.apply(new FiniteDuration(7, TimeUnit.MINUTES)),
-          Option.apply(new FiniteDuration(5, TimeUnit.MINUTES)));
+          new FiniteDuration(7, TimeUnit.MINUTES),
+          new FiniteDuration(5, TimeUnit.MINUTES));
 
   @RegisterExtension
   static MesosClusterExtension mesosCluster =

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import scala.Option;
-import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 @ExtendWith(TestUtils.JenkinsParameterResolver.class)

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
@@ -176,10 +176,4 @@ class MesosApiTest {
       assertThat(ex.getCause().getMessage(), is("Kill command for agent3 was dropped."));
     }
   }
-
-  @Test
-  void metricsPrefixSanitization() {
-    final String prefix = "I'm an invalid pref$x!.1";
-    assertThat(MesosApi.sanitize(prefix), is("I-m-an-invalid-pref-x-.1"));
-  }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosApiTest.java
@@ -56,7 +56,7 @@ class MesosApiTest {
 
     URL jenkinsUrl = j.getURL();
 
-    URL mesosUrl = mesosCluster.getMesosUrl();
+    String mesosUrl = mesosCluster.getMesosUrl().toString();
     MesosApi api =
         new MesosApi(
             mesosUrl,
@@ -79,7 +79,7 @@ class MesosApiTest {
   @Test
   public void stopAgent(JenkinsRule j) throws Exception {
 
-    URL mesosUrl = mesosCluster.getMesosUrl();
+    String mesosUrl = mesosCluster.getMesosUrl().toString();
     URL jenkinsUrl = j.getURL();
     MesosApi api =
         new MesosApi(


### PR DESCRIPTION
Summary:
This uses the `MasterDetector` from mesosphere/usi#118 to infer the
proper Mesos address from either a Zookeeper server list and path or an
HTTP address.

JIRA issues: DCOS_OSS-5588