### PR TITLE
Syncronize downstream master automatically.

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,5 @@
+version: "1"
+rules:
+  - base: master
+    upstream: jenkinsci:master
+    mergeMethod: merge 


### PR DESCRIPTION
This uses https://github.com/wei/pull to synchronize the Mesosphere fork
of jenkinsci/mesos-plugin automatically.